### PR TITLE
Improvement: create dependency folders only after successful install

### DIFF
--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -79,9 +79,6 @@ pub async fn download_dependency(
         fs::create_dir(&dependency_directory).unwrap();
     }
 
-    let mut file = File::create(&dependency_directory.join(dependency_name))
-        .await
-        .unwrap();
     let mut stream = match reqwest::get(dependency_url).await {
         Ok(res) => {
             if res.status() != 200 {
@@ -101,6 +98,10 @@ pub async fn download_dependency(
             });
         }
     };
+
+    let mut file = File::create(&dependency_directory.join(dependency_name))
+        .await
+        .unwrap();
 
     while let Some(chunk_result) = stream.next().await {
         match file.write_all(&chunk_result.unwrap()).await {


### PR DESCRIPTION
### Overview
Currently, soldeer would unconditionally create a new folder for each dependency, regardless of whether the installation was successful. If we attempt failed installation repeatedly under different names, it could lead to the accumulation of multiple empty folders within the dependencies directory.

### Changes
With the PR's changes, a new folder for a dependency will only be created if the installation process completes successfully. This improvement prevents the creation of unnecessary empty folders.