### PR TITLE
Fixes #66 and #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SolDeer ![Rust][rust-badge] [![License: MIT][license-badge]][license]
+# Soldeer ![Rust][rust-badge] [![License: MIT][license-badge]][license]
 
 [rust-badge]: https://img.shields.io/badge/Built%20with%20-Rust-e43716.svg
 [license]: https://opensource.org/licenses/MIT
@@ -122,6 +122,12 @@ soldeer install <dependency_name>~<version> <url>
 ```
 
 This command will download the zip file of the dependency, unzip it, install it in the `dependencies` directory.
+
+```bash
+soldeer install
+```
+
+This command will install all the dependencies from the `soldeer.toml`/`foundry.toml` file.
 
 ### How to push a new dependency to the repository
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -27,8 +27,8 @@ pub enum Subcommands {
     override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
 )]
 pub struct Install {
-    #[clap(required = true)]
-    pub dependency: String,
+    #[clap(required = false)]
+    pub dependency: Option<String>,
     #[clap(required = false)]
     pub remote_url: Option<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,8 +122,6 @@ pub fn define_config_file() -> Result<String, ConfigError> {
         filename = String::from(FOUNDRY_CONFIG_FILE.to_str().unwrap());
     };
 
-    println!("confiog file {}", filename);
-
     // check if the foundry.toml has the dependencies defined, if so then we setup the foundry.toml as the config file
     if fs::metadata(&filename).is_ok() {
         let contents = read_file_to_string(&filename.clone());

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,9 +14,12 @@ use std::fs::{
     self,
     File,
 };
-use std::io;
 use std::io::Write;
 use std::path::Path;
+use std::{
+    env,
+    io,
+};
 use toml::Table;
 use toml_edit::{
     value,
@@ -111,7 +114,15 @@ pub async fn read_config(filename: String) -> Result<Vec<Dependency>, ConfigErro
 }
 
 pub fn define_config_file() -> Result<String, ConfigError> {
-    let mut filename: String = String::from(FOUNDRY_CONFIG_FILE.to_str().unwrap());
+    let mut filename: String;
+    if cfg!(test) {
+        filename =
+            env::var("config_file").unwrap_or(String::from(FOUNDRY_CONFIG_FILE.to_str().unwrap()))
+    } else {
+        filename = String::from(FOUNDRY_CONFIG_FILE.to_str().unwrap());
+    };
+
+    println!("confiog file {}", filename);
 
     // check if the foundry.toml has the dependencies defined, if so then we setup the foundry.toml as the config file
     if fs::metadata(&filename).is_ok() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz".to_string());
+        env::set_var("base_url", "https://api.soldeer.xyz");
 
         let command = Subcommands::Install(Install {
             dependency: None,
@@ -485,7 +485,7 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz".to_string());
+        env::set_var("base_url", "https://api.soldeer.xyz");
 
         let command = Subcommands::Install(Install {
             dependency: None,
@@ -529,7 +529,7 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz".to_string());
+        env::set_var("base_url", "https://api.soldeer.xyz");
 
         let command = Subcommands::Update(Update {});
 
@@ -581,7 +581,7 @@ libs = ["dependencies"]
             target = format!("soldeer{}.toml", s);
         }
 
-        let path = env::current_dir().unwrap().join("test").join(&target);
+        let path = env::current_dir().unwrap().join("test").join(target);
         env::set_var("config_file", path.clone().to_str().unwrap());
         path
     }

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -298,6 +298,13 @@ async fn push_to_repo(
                 cause: "Unauthorized. Please login".to_string(),
             });
         }
+        StatusCode::PAYLOAD_TOO_LARGE => {
+            return Err(PushError {
+                name: (&dependency_name).to_string(),
+                version: (&dependency_version).to_string(),
+                cause: "The package is too big, it has over 50 MB".to_string(),
+            });
+        }
         _ => {
             return Err(PushError {
                 name: (&dependency_name).to_string(),

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -12,11 +12,6 @@ use std::{
     process::Command,
 };
 
-use rand::{
-    distributions::Alphanumeric,
-    Rng,
-};
-
 use serial_test::serial;
 use soldeer::{
     commands::{
@@ -25,7 +20,6 @@ use soldeer::{
     },
     errors::SoldeerError,
     DEPENDENCY_DIR,
-    FOUNDRY_CONFIG_FILE,
     LOCK_FILE,
 };
 use std::io::Write;
@@ -140,82 +134,8 @@ fn soldeer_install_invalid_dependency() {
     assert!(!Path::new(&path_dependency).exists());
 }
 
-#[test]
-#[serial]
-fn soldeer_install_moves_to_update() {
-    let _ = remove_dir_all(DEPENDENCY_DIR.clone());
-    let _ = remove_file(LOCK_FILE.clone());
-    // let config_file = FOUNDRY_CONFIG_FILE.to_str().unwrap();
-    let content = r#"
-# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
-
-[profile.default]
-script = "script"
-solc = "0.8.26"
-src = "src"
-test = "test"
-libs = ["dependencies"]
-
-[dependencies]
-"@gearbox-protocol-periphery-v3" = "1.6.1"
-"@openzeppelin-contracts" = "5.0.2"   
-"#;
-
-    let target_config = define_config(true);
-
-    write_to_config(&target_config, content);
-
-    let command = Subcommands::Install(Install {
-        dependency: None,
-        remote_url: None,
-    });
-
-    match soldeer::run(command) {
-        Ok(_) => {}
-        Err(_) => {
-            assert_eq!("Invalid State", "")
-        }
-    }
-
-    let path_dependency = DEPENDENCY_DIR.join("forge-std");
-    let path_zip = DEPENDENCY_DIR.join("forge-std.zip");
-
-    assert!(!Path::new(&path_zip).exists());
-    assert!(!Path::new(&path_dependency).exists());
-}
-
 fn clean_test_env(test_project: &PathBuf) {
     let _ = remove_dir_all(DEPENDENCY_DIR.clone());
     let _ = remove_file(LOCK_FILE.clone());
     let _ = remove_dir_all(test_project);
-}
-
-fn write_to_config(target_file: &PathBuf, content: &str) {
-    if target_file.exists() {
-        let _ = remove_file(target_file);
-    }
-    let mut file: std::fs::File = fs::OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .open(target_file)
-        .unwrap();
-    if let Err(e) = write!(file, "{}", content) {
-        eprintln!("Couldn't write to the config file: {}", e);
-    }
-}
-
-fn define_config(foundry: bool) -> PathBuf {
-    let s: String = rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(7)
-        .map(char::from)
-        .collect();
-    let mut target = format!("foundry{}.toml", s);
-    if !foundry {
-        target = format!("soldeer{}.toml", s);
-    }
-
-    let path = env::current_dir().unwrap().join("test").join(&target);
-    env::set_var("config_file", target.clone().to_string());
-    path
 }

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -12,6 +12,11 @@ use std::{
     process::Command,
 };
 
+use rand::{
+    distributions::Alphanumeric,
+    Rng,
+};
+
 use serial_test::serial;
 use soldeer::{
     commands::{
@@ -20,6 +25,7 @@ use soldeer::{
     },
     errors::SoldeerError,
     DEPENDENCY_DIR,
+    FOUNDRY_CONFIG_FILE,
     LOCK_FILE,
 };
 use std::io::Write;
@@ -32,7 +38,7 @@ fn soldeer_install_valid_dependency() {
     let test_project = env::current_dir().unwrap().join("test_project");
     clean_test_env(&test_project);
     let command = Subcommands::Install(Install {
-        dependency: "forge-std~1.8.2".to_string(),
+        dependency: Some("forge-std~1.8.2".to_string()),
         remote_url: None,
     });
 
@@ -109,7 +115,7 @@ contract Test {
 #[serial]
 fn soldeer_install_invalid_dependency() {
     let command = Subcommands::Install(Install {
-        dependency: "forge-std".to_string(),
+        dependency: Some("forge-std".to_string()),
         remote_url: None,
     });
 
@@ -134,8 +140,82 @@ fn soldeer_install_invalid_dependency() {
     assert!(!Path::new(&path_dependency).exists());
 }
 
+#[test]
+#[serial]
+fn soldeer_install_moves_to_update() {
+    let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+    let _ = remove_file(LOCK_FILE.clone());
+    // let config_file = FOUNDRY_CONFIG_FILE.to_str().unwrap();
+    let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"@gearbox-protocol-periphery-v3" = "1.6.1"
+"@openzeppelin-contracts" = "5.0.2"   
+"#;
+
+    let target_config = define_config(true);
+
+    write_to_config(&target_config, content);
+
+    let command = Subcommands::Install(Install {
+        dependency: None,
+        remote_url: None,
+    });
+
+    match soldeer::run(command) {
+        Ok(_) => {}
+        Err(_) => {
+            assert_eq!("Invalid State", "")
+        }
+    }
+
+    let path_dependency = DEPENDENCY_DIR.join("forge-std");
+    let path_zip = DEPENDENCY_DIR.join("forge-std.zip");
+
+    assert!(!Path::new(&path_zip).exists());
+    assert!(!Path::new(&path_dependency).exists());
+}
+
 fn clean_test_env(test_project: &PathBuf) {
     let _ = remove_dir_all(DEPENDENCY_DIR.clone());
     let _ = remove_file(LOCK_FILE.clone());
     let _ = remove_dir_all(test_project);
+}
+
+fn write_to_config(target_file: &PathBuf, content: &str) {
+    if target_file.exists() {
+        let _ = remove_file(target_file);
+    }
+    let mut file: std::fs::File = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(target_file)
+        .unwrap();
+    if let Err(e) = write!(file, "{}", content) {
+        eprintln!("Couldn't write to the config file: {}", e);
+    }
+}
+
+fn define_config(foundry: bool) -> PathBuf {
+    let s: String = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(7)
+        .map(char::from)
+        .collect();
+    let mut target = format!("foundry{}.toml", s);
+    if !foundry {
+        target = format!("soldeer{}.toml", s);
+    }
+
+    let path = env::current_dir().unwrap().join("test").join(&target);
+    env::set_var("config_file", target.clone().to_string());
+    path
 }


### PR DESCRIPTION
Fixes the message if one tries to publish a very large package, over 50 MB.
Now you can use `soldeer install` to install the dependencies that are described in the foundry.toml