### PR TITLE
Fix some random tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ src/soldeer.toml
 test/*
 !emptyfile
 !emptyfile2
+test_push_sensitive

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ path = "src/main.rs"
 [features]
 default = ["rustls"]
 rustls = ["reqwest/rustls-tls"]
+
+[profile.test]
+opt-level = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,9 +279,10 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 .path
                 .unwrap_or(get_current_working_dir().to_str().unwrap().to_string());
             let path_buf = PathBuf::from(&path);
+            let dry_run = push.dry_run.is_some() && push.dry_run.unwrap();
 
             // Check for sensitive files or directories
-            if check_dotfiles_recursive(&path_buf) && !prompt_user_for_confirmation() {
+            if !dry_run && check_dotfiles_recursive(&path_buf) && !prompt_user_for_confirmation() {
                 println!("{}", Paint::yellow("Push operation aborted by the user."));
                 return Ok(());
             }
@@ -307,7 +308,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 &dependency_name,
                 &dependency_version,
                 PathBuf::from(&path),
-                push.dry_run.unwrap(),
+                dry_run,
             )
             .await
             {

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -73,17 +73,24 @@ pub async fn push_version(
     );
 
     let files_to_copy: Vec<FilePair> = filter_files_to_copy(&root_directory_path);
-    let zip_archive = zip_file(
+
+    let zip_archive = match zip_file(
         dependency_name,
         dependency_version,
         &root_directory_path,
         &files_to_copy,
         &file_name,
-    )
-    .unwrap();
+    ) {
+        Ok(zip) => zip,
+        Err(err) => {
+            return Err(err);
+        }
+    };
+
     if dry_run {
         return Ok(());
     }
+
     match push_to_repo(&zip_archive, dependency_name, dependency_version).await {
         Ok(_) => {}
         Err(error) => {


### PR DESCRIPTION
When running dry-run the warnings should not appear for .dot files