### PR TITLE
Adding using git for pulling dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -563,6 +563,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
@@ -745,6 +760,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -843,6 +859,46 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -960,6 +1016,24 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1121,6 +1195,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1199,9 +1320,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64",
  "bytes",
@@ -1222,6 +1343,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -1285,12 +1407,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustls"
-version = "0.22.4"
+name = "rustc-hash"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustls"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1316,9 +1444,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1363,18 +1491,18 @@ checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1383,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -1487,9 +1615,9 @@ checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "simple-home-dir"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c433538e900807402974e89beb88a98bda36e6f70f09a7225cdf11d013b8efe8"
+checksum = "c221cbc8c1ff6bdf949b12cc011456c510ec6840654b444c7374c78e928ce344"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -1528,6 +1656,7 @@ dependencies = [
  "email-address-parser",
  "env_logger",
  "futures",
+ "git2",
  "mockito",
  "once_cell",
  "rand",
@@ -1582,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "thiserror"
@@ -1623,9 +1752,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1641,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1652,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -1676,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1697,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
 dependencies = [
  "indexmap",
  "serde",
@@ -1744,7 +1873,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1829,13 +1970,19 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,31 +13,32 @@ repository = "https://github.com/mario-eth/soldeer"
 version = "0.2.17"
 
 [dependencies]
-chrono = {version = "0.4.37", default-features = false, features = [
+chrono = {version = "0.4.38", default-features = false, features = [
   "std",
   "serde",
 ]}
-clap = {version = "4.5.4", features = ["derive"]}
+clap = {version = "4.5.9", features = ["derive"]}
 email-address-parser = "2.0.0"
 futures = "0.3.30"
+git2 = "0.19.0"
 once_cell = "1.19"
-regex = "1.10.4"
-reqwest = {version = "0.12.4", features = [
+regex = "1.10.5"
+reqwest = {version = "0.12.5", features = [
   "blocking",
   "json",
   "multipart",
   "stream",
 ], default-features = false}
 rpassword = "7.3.1"
-serde = "1.0.197"
-serde_derive = "1.0.197"
-serde_json = "1.0.115"
+serde = "1.0.204"
+serde_derive = "1.0.204"
+serde_json = "1.0.120"
 sha256 = "1.5.0"
-simple-home-dir = "0.3.2"
-tokio = {version = "1.37.0", features = ["rt-multi-thread", "macros"]}
-toml = "0.8.13"
-toml_edit = "0.22.13"
-uuid = {version = "1.8.0", features = ["serde", "v4"]}
+simple-home-dir = "0.3.5"
+tokio = {version = "1.38.0", features = ["rt-multi-thread", "macros"]}
+toml = "0.8.14"
+toml_edit = "0.22.15"
+uuid = {version = "1.10.0", features = ["serde", "v4"]}
 walkdir = "2.5.0"
 yansi = "1.0.1"
 yash-fnmatch = "1.1.1"
@@ -48,7 +49,8 @@ zip-extract = "0.1.3"
 env_logger = "0.11.3"
 mockito = "1.4.0"
 rand = "0.8.5"
-serial_test = "3.0.0"
+serial_test = "3.1.1"
+
 [lib]
 name = "soldeer"
 path = "src/lib.rs"

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,11 +2,11 @@
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
 [profile.default]
-libs = ["dependencies"]
 script = "script"
-solc = "0.8.20"
+solc = "0.8.26"
 src = "src"
 test = "test"
+libs = ["dependencies"]
 
 [dependencies]
 forge-std = "1.8.2"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,7 +22,12 @@ pub enum Subcommands {
 
 #[derive(Debug, Clone, Parser)]
 #[clap(
-    about = "Install a dependency from soldeer repository or from a custom url that points to a zip file.\nExample: soldeer install @openzeppelin-contracts~2.3.0 the `~` is very important to differentiate between the name and the version that needs to be installed.",
+    about = "Install a dependency from soldeer repository or from a custom url that points to a zip file or from git using a git link. 
+    IMPORTANT!! The `~` when specifying the dependency is very important to differentiate between the name and the version that needs to be installed.
+    Example from remote repository: soldeer install @openzeppelin-contracts~2.3.0 
+    Example custom url: soldeer install @openzeppelin-contracts~2.3.0 https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v5.0.2.zip
+    Example git: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git
+    Example git with specified commit: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git 05f218fb6617932e56bf5388c3b389c3028a7b73\n",
     after_help = "For more information, read the README.md",
     override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
 )]
@@ -31,6 +36,8 @@ pub struct Install {
     pub dependency: Option<String>,
     #[clap(required = false)]
     pub remote_url: Option<String>,
+    #[clap(required = false)]
+    pub commit: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -1,6 +1,11 @@
 use futures::StreamExt;
+use git2::Oid;
+use git2::Repository;
+use std::error::Error;
 use std::fs;
+use std::fs::remove_dir_all;
 use std::io::Cursor;
+use std::path::Path;
 use std::path::PathBuf;
 use tokio::{
     fs::File,
@@ -11,129 +16,95 @@ use yansi::Paint;
 use crate::config::Dependency;
 use crate::errors::DownloadError;
 use crate::errors::UnzippingError;
-use crate::remote::get_dependency_url_remote;
+use crate::utils::get_download_tunnel;
 use crate::utils::read_file;
+use crate::utils::sha256_digest;
 use crate::DEPENDENCY_DIR;
 
 pub async fn download_dependencies(
     dependencies: &[Dependency],
     clean: bool,
-) -> Result<(), DownloadError> {
+) -> Result<Vec<String>, DownloadError> {
     // clean dependencies folder if flag is true
     if clean {
         clean_dependency_directory();
     }
     // downloading dependencies to dependencies folder
-    futures::future::join_all(dependencies.iter().map(|dep| {
-        async {
-            let file_name: String = format!("{}-{}.zip", dep.name, dep.version);
-            download_dependency(&file_name, &dep.url).await
-        }
-    }))
+    let hashes: Vec<String> = futures::future::join_all(
+        dependencies
+            .iter()
+            .map(|dep| async { download_dependency(&dep.clone()).await }),
+    )
     .await
     .into_iter()
-    .collect::<Result<Vec<()>, DownloadError>>()?;
+    .collect::<Result<Vec<String>, DownloadError>>()?;
 
-    Ok(())
+    Ok(hashes)
 }
 
 // un-zip-ing dependencies to dependencies folder
 pub fn unzip_dependencies(dependencies: &[Dependency]) -> Result<(), UnzippingError> {
     for dependency in dependencies.iter() {
-        match unzip_dependency(&dependency.name, &dependency.version) {
-            Ok(_) => {}
-            Err(err) => {
-                return Err(err);
+        let via_http = get_download_tunnel(&dependency.url) != "git";
+        if via_http {
+            match unzip_dependency(&dependency.name, &dependency.version) {
+                Ok(_) => {}
+                Err(err) => {
+                    return Err(err);
+                }
             }
         }
     }
     Ok(())
 }
 
-pub async fn download_dependency_remote(
-    dependency_name: &String,
-    dependency_version: &String,
-) -> Result<String, DownloadError> {
-    let dependency_url = match get_dependency_url_remote(dependency_name, dependency_version).await
-    {
-        Ok(url) => url,
-        Err(err) => return Err(err),
-    };
-
-    match download_dependency(
-        &format!("{}-{}.zip", &dependency_name, &dependency_version),
-        &dependency_url,
-    )
-    .await
-    {
-        Ok(_) => Ok(dependency_url),
-        Err(err) => Err(err),
-    }
-}
-
-pub async fn download_dependency(
-    dependency_name: &str,
-    dependency_url: &str,
-) -> Result<(), DownloadError> {
+pub async fn download_dependency(dependency: &Dependency) -> Result<String, DownloadError> {
     let dependency_directory: PathBuf = DEPENDENCY_DIR.clone();
     if !DEPENDENCY_DIR.is_dir() {
         fs::create_dir(&dependency_directory).unwrap();
     }
 
-    let mut stream = match reqwest::get(dependency_url).await {
-        Ok(res) => {
-            if res.status() != 200 {
-                return Err(DownloadError {
-                    name: dependency_name.to_string(),
-                    version: dependency_url.to_string(),
-                    cause: format!("Could not download, status: {:?}", res.status()),
-                });
-            }
-            res.bytes_stream()
-        }
-        Err(_) => {
-            return Err(DownloadError {
-                name: dependency_name.to_string(),
-                version: dependency_url.to_string(),
-                cause: "Unknown error".to_string(),
-            });
-        }
-    };
-
-    let mut file = File::create(&dependency_directory.join(dependency_name))
-        .await
-        .unwrap();
-
-    while let Some(chunk_result) = stream.next().await {
-        match file.write_all(&chunk_result.unwrap()).await {
+    let tunnel = get_download_tunnel(&dependency.url);
+    let hash: String;
+    if tunnel == "http" {
+        match download_via_http(&dependency, &dependency_directory).await {
             Ok(_) => {}
-            Err(_) => {
+            Err(err) => {
                 return Err(DownloadError {
-                    name: dependency_name.to_string(),
-                    version: dependency_url.to_string(),
-                    cause: "Unknown error".to_string(),
+                    name: dependency.name.to_string(),
+                    version: dependency.url.to_string(),
+                    cause: err.cause,
                 });
             }
         }
+        hash = sha256_digest(&dependency.name, &dependency.version);
+    } else if tunnel == "git" {
+        hash = match download_via_git(&dependency, &dependency_directory).await {
+            Ok(h) => h,
+            Err(err) => {
+                return Err(DownloadError {
+                    name: dependency.name.to_string(),
+                    version: dependency.url.to_string(),
+                    cause: err.cause,
+                });
+            }
+        };
+    } else {
+        return Err(DownloadError {
+            name: dependency.name.to_string(),
+            version: dependency.url.to_string(),
+            cause: "Download tunnel unknown".to_string(),
+        });
     }
-
-    match file.flush().await {
-        Ok(_) => {}
-        Err(_) => {
-            return Err(DownloadError {
-                name: dependency_name.to_string(),
-                version: dependency_url.to_string(),
-                cause: "Unknown error".to_string(),
-            });
-        }
-    };
-
     println!(
         "{}",
-        Paint::green(&format!("Dependency {dependency_name} downloaded!"))
+        Paint::green(&format!(
+            "Dependency {}-{} downloaded!",
+            dependency.name, dependency.version
+        ))
     );
 
-    Ok(())
+    Ok(hash)
 }
 
 pub fn unzip_dependency(
@@ -172,41 +143,234 @@ pub fn clean_dependency_directory() {
     }
 }
 
+async fn download_via_git(
+    dependency: &Dependency,
+    dependency_directory: &Path,
+) -> Result<String, DownloadError> {
+    let target_dir = &format!("{}-{}", dependency.name, dependency.version);
+    let path = dependency_directory.join(target_dir);
+    if path.exists() {
+        let _ = remove_dir_all(path);
+    }
+
+    let http_url = transform_git_to_http(&dependency.url);
+    let repo = match Repository::clone(http_url.as_str(), dependency_directory.join(target_dir)) {
+        Ok(r) => {
+            println!(
+                "{}",
+                Paint::green(&format!("Successfully cloned dependency to {:?}", r.path()))
+            );
+            r
+        }
+        Err(err) => {
+            return Err(DownloadError {
+                name: dependency.name.to_string(),
+                version: dependency.version.to_string(),
+                cause: format!(
+                    "Dependency {}~{} could not be downloaded via git.\nCause: {}",
+                    dependency.name.clone(),
+                    dependency.version.clone(),
+                    err.message()
+                ),
+            });
+        }
+    };
+
+    if !dependency.hash.is_empty() {
+        // Find the commit
+        let oid = Oid::from_str(&dependency.hash).unwrap();
+        let commit = repo.find_commit(oid).unwrap();
+
+        // Checkout the commit
+        let tree: git2::Tree = commit.tree().unwrap();
+        repo.checkout_tree(tree.as_object(), None).unwrap();
+        repo.set_head_detached(commit.id()).unwrap();
+        return Ok(dependency.hash.clone());
+    }
+
+    let head = repo.head().unwrap();
+
+    // Resolve the reference to the actual commit object
+    let commit = head.peel_to_commit().unwrap();
+
+    // Get the commit hash
+    let commit_hash = commit.id().to_string();
+    Ok(commit_hash)
+}
+
+async fn download_via_http(
+    dependency: &Dependency,
+    dependency_directory: &Path,
+) -> Result<(), DownloadError> {
+    let zip_to_download = &format!("{}-{}.zip", dependency.name, dependency.version);
+    let mut stream = match reqwest::get(&dependency.url).await {
+        Ok(res) => {
+            if res.status() != 200 {
+                return Err(DownloadError {
+                    name: dependency.name.clone().to_string(),
+                    version: dependency.url.clone().to_string(),
+                    cause: format!(
+                        "Dependency {}~{} could not be downloaded via http.\nStatus: {}",
+                        dependency.name.clone(),
+                        dependency.version.clone(),
+                        res.status()
+                    ),
+                });
+            }
+            res.bytes_stream()
+        }
+        Err(err) => {
+            return Err(DownloadError {
+                name: dependency.name.clone().to_string(),
+                version: dependency.url.clone().to_string(),
+                cause: format!("Unknown error: {:?}", err.source()),
+            });
+        }
+    };
+
+    let mut file = File::create(&dependency_directory.join(zip_to_download))
+        .await
+        .unwrap();
+
+    while let Some(chunk_result) = stream.next().await {
+        match file.write_all(&chunk_result.unwrap()).await {
+            Ok(_) => {}
+            Err(err) => {
+                return Err(DownloadError {
+                    name: dependency.name.to_string(),
+                    version: dependency.version.to_string(),
+                    cause: format!("Unknown error: {:?}", err.source()),
+                });
+            }
+        }
+    }
+
+    match file.flush().await {
+        Ok(_) => {}
+        Err(err) => {
+            return Err(DownloadError {
+                name: dependency.name.to_string(),
+                version: dependency.url.to_string(),
+                cause: format!("Unknown error: {:?}", err.source()),
+            });
+        }
+    };
+    Ok(())
+}
+
+fn transform_git_to_http(url: &str) -> String {
+    if url.starts_with("git@github.com:") {
+        let repo_path = &url["git@github.com:".len()..];
+        format!("https://github.com/{}", repo_path)
+    } else if url.starts_with("git@gitlab.com:") {
+        let repo_path = &url["git@gitlab.com:".len()..];
+        format!("https://gitlab.com/{}", repo_path)
+    } else {
+        url.to_string()
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::vec_init_then_push)]
 mod tests {
     use super::*;
     use crate::janitor::healthcheck_dependency;
     use serial_test::serial;
-    use std::env;
     use std::fs::metadata;
     use std::path::Path;
 
     #[tokio::test]
     #[serial]
-    async fn download_dependencies_one_success() {
+    async fn download_dependencies_http_one_success() {
         let mut dependencies: Vec<Dependency> = Vec::new();
         let dependency = Dependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
+            hash: String::new()
         };
         dependencies.push(dependency.clone());
-        download_dependencies(&dependencies, false).await.unwrap();
+        let hashes = download_dependencies(&dependencies, false).await.unwrap();
         let path_zip =
             DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name, &dependency.version));
-        assert!(Path::new(&path_zip).exists());
+        assert!(path_zip.exists());
+        assert!(hashes.len() == 1);
+        assert!(!hashes[0].is_empty());
         clean_dependency_directory()
     }
 
     #[tokio::test]
     #[serial]
-    async fn download_dependencies_two_success() {
+    async fn download_dependencies_git_one_success() {
+        clean_dependency_directory();
+        let mut dependencies: Vec<Dependency> = Vec::new();
+        let dependency = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.3.0".to_string(),
+            url: "git@github.com:transmissions11/solmate.git".to_string(),
+            hash: String::new(),
+        };
+        dependencies.push(dependency.clone());
+        let hashes = download_dependencies(&dependencies, false).await.unwrap();
+        let path_dir = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
+        assert!(path_dir.exists());
+        assert!(path_dir.join("src").join("auth").join("Owned.sol").exists());
+        assert!(hashes.len() == 1);
+        assert!(!hashes[0].is_empty());
+        clean_dependency_directory()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn download_dependencies_gitlab_giturl_one_success() {
+        clean_dependency_directory();
+        let mut dependencies: Vec<Dependency> = Vec::new();
+        let dependency = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.3.0".to_string(),
+            url: "git@gitlab.com:mario4582928/Mario.git".to_string(),
+            hash: String::new(),
+        };
+        dependencies.push(dependency.clone());
+        let hashes = download_dependencies(&dependencies, false).await.unwrap();
+        let path_dir = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
+        assert!(path_dir.exists());
+        assert!(path_dir.join("README.md").exists());
+        assert!(hashes.len() == 1);
+        assert_eq!(hashes[0], "bedb1775bd60e3e142a6db863982254a4b891b20"); // this is the last commit, hash == commit
+        clean_dependency_directory()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn download_dependencies_gitlab_httpurl_one_success() {
+        clean_dependency_directory();
+        let mut dependencies: Vec<Dependency> = Vec::new();
+        let dependency = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.3.0".to_string(),
+            url: "https://gitlab.com/mario4582928/Mario.git".to_string(),
+            hash: String::new(),
+        };
+        dependencies.push(dependency.clone());
+        let hashes = download_dependencies(&dependencies, false).await.unwrap();
+        let path_dir = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
+        assert!(path_dir.exists());
+        assert!(path_dir.join("README.md").exists());
+        assert!(hashes.len() == 1);
+        assert_eq!(hashes[0], "bedb1775bd60e3e142a6db863982254a4b891b20"); // this is the last commit, hash == commit
+        clean_dependency_directory()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn download_dependencies_http_two_success() {
         let mut dependencies: Vec<Dependency> = Vec::new();
         let  dependency_one = Dependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
+            hash: String::new()
         };
         dependencies.push(dependency_one.clone());
 
@@ -214,21 +378,73 @@ mod tests {
             name: "@uniswap-v2-core".to_string(),
             version: "1.0.0-beta.4".to_string(),
             url: "https://soldeer-revisions.s3.amazonaws.com/@uniswap-v2-core/1_0_0-beta_4_22-01-2024_13:18:27_v2-core.zip".to_string(),
+            hash: String::new()
         };
 
         dependencies.push(dependency_two.clone());
-        download_dependencies(&dependencies, false).await.unwrap();
+        let hashes = download_dependencies(&dependencies, false).await.unwrap();
         let mut path_zip = DEPENDENCY_DIR.join(format!(
             "{}-{}.zip",
             &dependency_one.name, &dependency_one.version
         ));
-        assert!(Path::new(&path_zip).exists());
+        assert!(path_zip.exists());
 
         path_zip = DEPENDENCY_DIR.join(format!(
             "{}-{}.zip",
             &dependency_two.name, &dependency_two.version
         ));
-        assert!(Path::new(&path_zip).exists());
+        assert!(path_zip.exists());
+        assert!(hashes.len() == 2);
+        assert!(!hashes[0].is_empty());
+        assert!(!hashes[1].is_empty());
+        clean_dependency_directory()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn download_dependencies_git_two_success() {
+        let mut dependencies: Vec<Dependency> = Vec::new();
+        let dependency_one = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.3.0".to_string(),
+            url: "git@github.com:transmissions11/solmate.git".to_string(),
+            hash: String::new(),
+        };
+        dependencies.push(dependency_one.clone());
+
+        let dependency_two = Dependency {
+            name: "@uniswap-v2-core".to_string(),
+            version: "1.0.0-beta.4".to_string(),
+            url: "https://github.com/OpenZeppelin/openzeppelin-contracts.git".to_string(),
+            hash: String::new(),
+        };
+
+        dependencies.push(dependency_two.clone());
+        let hashes = download_dependencies(&dependencies, false).await.unwrap();
+        let mut path_dir = DEPENDENCY_DIR.join(format!(
+            "{}-{}",
+            &dependency_one.name, &dependency_one.version
+        ));
+        let mut path_dir_two = DEPENDENCY_DIR.join(format!(
+            "{}-{}",
+            &dependency_two.name, &dependency_two.version
+        ));
+        assert!(path_dir.exists());
+        assert!(path_dir_two.exists());
+
+        path_dir = DEPENDENCY_DIR.join(format!(
+            "{}-{}",
+            &dependency_one.name, &dependency_one.version
+        ));
+        path_dir_two = DEPENDENCY_DIR.join(format!(
+            "{}-{}",
+            &dependency_two.name, &dependency_two.version
+        ));
+        assert!(path_dir.exists());
+        assert!(path_dir_two.exists());
+        assert!(hashes.len() == 2);
+        assert!(!hashes[0].is_empty());
+        assert!(!hashes[1].is_empty());
         clean_dependency_directory()
     }
 
@@ -240,7 +456,7 @@ mod tests {
             name: "@openzeppelin-contracts".to_string(),
             version: "download-dep-v1".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
-        };
+            hash: String::new() };
         dependencies.push(dependency_one.clone());
 
         download_dependencies(&dependencies, false).await.unwrap();
@@ -254,15 +470,17 @@ mod tests {
                 name: "@openzeppelin-contracts".to_string(),
                 version: "download-dep-v1".to_string(),
                 url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.4.0.zip".to_string(),
-            };
+                hash: String::new()};
 
         dependencies = Vec::new();
         dependencies.push(dependency_two.clone());
 
-        download_dependencies(&dependencies, false).await.unwrap();
+        let hashes = download_dependencies(&dependencies, false).await.unwrap();
         let size_of_two = fs::metadata(Path::new(&path_zip)).unwrap().len();
 
         assert!(size_of_two > size_of_one);
+        assert!(hashes.len() == 1);
+        assert!(!hashes[0].is_empty());
         clean_dependency_directory()
     }
 
@@ -274,7 +492,7 @@ mod tests {
             name: "@uniswap-v2-core".to_string(),
             version: "1.0.0-beta.4".to_string(),
             url: "https://soldeer-revisions.s3.amazonaws.com/@uniswap-v2-core/1_0_0-beta_4_22-01-2024_13:18:27_v2-core.zip".to_string(),
-        };
+            hash: String::new()};
 
         dependencies.push(dependency_old.clone());
         download_dependencies(&dependencies, false).await.unwrap();
@@ -284,33 +502,59 @@ mod tests {
             "{}-{}.zip",
             &dependency_old.name, &dependency_old.version
         ));
-        assert!(Path::new(&path_zip_old).exists());
+        assert!(path_zip_old.exists());
 
         let dependency = Dependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
-        };
+            hash: String::new()};
         dependencies = Vec::new();
         dependencies.push(dependency.clone());
 
-        download_dependencies(&dependencies, true).await.unwrap();
+        let hashes = download_dependencies(&dependencies, true).await.unwrap();
         let path_zip =
             DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name, &dependency.version));
-        assert!(!Path::new(&path_zip_old).exists());
-        assert!(Path::new(&path_zip).exists());
+        assert!(!path_zip_old.exists());
+        assert!(path_zip.exists());
+        assert!(hashes.len() == 1);
+        assert!(!hashes[0].is_empty());
         clean_dependency_directory()
     }
 
     #[tokio::test]
     #[serial]
-    async fn download_dependencies_one_fail() {
+    async fn download_dependencies_http_one_fail() {
         let mut dependencies: Vec<Dependency> = Vec::new();
 
         let dependency = Dependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~.zip".to_string(),
+            hash: String::new()};
+        dependencies.push(dependency.clone());
+
+        match download_dependencies(&dependencies, false).await {
+            Ok(_) => {
+                assert_eq!("Invalid state", "");
+            }
+            Err(err) => {
+                assert_eq!(err.cause, "Dependency @openzeppelin-contracts~2.3.0 could not be downloaded via http.\nStatus: 404 Not Found");
+            }
+        }
+        clean_dependency_directory()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn download_dependencies_git_one_fail() {
+        let mut dependencies: Vec<Dependency> = Vec::new();
+
+        let dependency = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.3.0".to_string(),
+            url: "git@github.com:transmissions11/solmate-wrong.git".to_string(),
+            hash: String::new(),
         };
         dependencies.push(dependency.clone());
 
@@ -319,7 +563,7 @@ mod tests {
                 assert_eq!("Invalid state", "");
             }
             Err(err) => {
-                assert_eq!(err.cause, "Could not download, status: 404");
+                assert_eq!(err.cause, "Dependency @openzeppelin-contracts~2.3.0 could not be downloaded via git.\nCause: remote authentication required but no callback set");
             }
         }
         clean_dependency_directory()
@@ -333,7 +577,7 @@ mod tests {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
-        };
+            hash: String::new() };
         dependencies.push(dependency.clone());
         download_dependencies(&dependencies, false).await.unwrap();
         let path = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
@@ -359,6 +603,7 @@ mod tests {
             version: "2.3.0".to_string(),
             url: "https://freetestdata.com/wp-content/uploads/2022/02/Free_Test_Data_117KB_JPG.jpg"
                 .to_string(),
+            hash: String::new(),
         };
         dependencies.push(dependency.clone());
         download_dependencies(&dependencies, false).await.unwrap();
@@ -382,74 +627,81 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn download_dependency_remote_success() {
-        env::set_var("base_url", "https://api.soldeer.xyz");
-
-        let dependency = Dependency {
-            name: "@openzeppelin-contracts".to_string(),
-            version: "2.3.0".to_string(),
-            url: "".to_string(),
-        };
-        download_dependency_remote(&dependency.name, &dependency.version)
-            .await
-            .unwrap();
-
-        let path_zip =
-            DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name, &dependency.version));
-        assert!(Path::new(&path_zip).exists());
-        clean_dependency_directory();
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn download_dependency_remote_non_existent_fail() {
-        env::set_var("base_url", "https://api.soldeer.xyz");
-
-        let dependency = Dependency {
-            name: "@wrong-dependency".to_string(),
-            version: "2.3.0".to_string(),
-            url: "".to_string(),
-        };
-        match download_dependency_remote(&dependency.name, &dependency.version).await {
-            Ok(_) => {
-                clean_dependency_directory();
-                assert_eq!("Wrong State", "");
-            }
-            Err(err) => {
-                assert_eq!(
-                    err,
-                    DownloadError {
-                        name: dependency.name.to_string(),
-                        version: dependency.version.to_string(),
-                        cause: "Could not get the dependency URL".to_string(),
-                    }
-                )
-            }
-        }
-
-        clean_dependency_directory();
-    }
-
-    #[tokio::test]
-    #[serial]
     async fn download_unzip_check_integrity() {
         let mut dependencies: Vec<Dependency> = Vec::new();
         dependencies.push(Dependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "3.3.0-custom-test".to_string(),
             url: "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/3_3_0-rc_2_22-01-2024_13:12:57_contracts.zip".to_string(),
+            hash: String::new()
         });
         download_dependencies(&dependencies, false).await.unwrap();
         unzip_dependency(&dependencies[0].name, &dependencies[0].version).unwrap();
         healthcheck_dependency("@openzeppelin-contracts", "3.3.0-custom-test").unwrap();
-        assert!(Path::new(
-            &DEPENDENCY_DIR
-                .join("@openzeppelin-contracts-3.3.0-custom-test")
-                .join("token")
-                .join("ERC20")
-                .join("ERC20.sol")
-        )
-        .exists());
+        assert!(DEPENDENCY_DIR
+            .join("@openzeppelin-contracts-3.3.0-custom-test")
+            .join("token")
+            .join("ERC20")
+            .join("ERC20.sol")
+            .exists());
         clean_dependency_directory()
+    }
+
+    #[test]
+    fn get_download_tunnel_http() {
+        assert_eq!(
+            get_download_tunnel(
+                "https://github.com/foundry-rs/forge-std/archive/refs/tags/v1.9.1.zip"
+            ),
+            "http"
+        );
+    }
+
+    #[test]
+    fn get_download_tunnel_git_giturl() {
+        assert_eq!(
+            get_download_tunnel("git@github.com:foundry-rs/forge-std.git"),
+            "git"
+        );
+    }
+
+    #[test]
+    fn get_download_tunnel_git_githttp() {
+        assert_eq!(
+            get_download_tunnel("https://github.com/foundry-rs/forge-std.git"),
+            "git"
+        );
+    }
+
+    #[test]
+    fn transform_git_giturl_to_http_success() {
+        assert_eq!(
+            transform_git_to_http("git@github.com:foundry-rs/forge-std.git"),
+            "https://github.com/foundry-rs/forge-std.git"
+        );
+    }
+
+    #[test]
+    fn transform_git_httpurl_to_http_success() {
+        assert_eq!(
+            transform_git_to_http("https://github.com/foundry-rs/forge-std.git"),
+            "https://github.com/foundry-rs/forge-std.git"
+        );
+    }
+
+    #[test]
+    fn transform_gitlab_giturl_to_http_success() {
+        assert_eq!(
+            transform_git_to_http("git@gitlab.com:mario4582928/Mario.git"),
+            "https://gitlab.com/mario4582928/Mario.git"
+        );
+    }
+
+    #[test]
+    fn transform_gitlab_httpurl_to_http_success() {
+        assert_eq!(
+            transform_git_to_http("https://gitlab.com/mario4582928/Mario.git"),
+            "https://gitlab.com/mario4582928/Mario.git"
+        );
     }
 }

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -67,7 +67,7 @@ pub async fn download_dependency(dependency: &Dependency) -> Result<String, Down
     let tunnel = get_download_tunnel(&dependency.url);
     let hash: String;
     if tunnel == "http" {
-        match download_via_http(&dependency, &dependency_directory).await {
+        match download_via_http(dependency, &dependency_directory).await {
             Ok(_) => {}
             Err(err) => {
                 return Err(DownloadError {
@@ -79,7 +79,7 @@ pub async fn download_dependency(dependency: &Dependency) -> Result<String, Down
         }
         hash = sha256_digest(&dependency.name, &dependency.version);
     } else if tunnel == "git" {
-        hash = match download_via_git(&dependency, &dependency_directory).await {
+        hash = match download_via_git(dependency, &dependency_directory).await {
             Ok(h) => h,
             Err(err) => {
                 return Err(DownloadError {
@@ -259,11 +259,11 @@ async fn download_via_http(
 }
 
 fn transform_git_to_http(url: &str) -> String {
-    if url.starts_with("git@github.com:") {
-        let repo_path = &url["git@github.com:".len()..];
+    if let Some(stripped) = url.strip_prefix("git@github.com:") {
+        let repo_path = stripped;
         format!("https://github.com/{}", repo_path)
-    } else if url.starts_with("git@gitlab.com:") {
-        let repo_path = &url["git@gitlab.com:".len()..];
+    } else if let Some(stripped) = url.strip_prefix("git@gitlab.com:") {
+        let repo_path = stripped;
         format!("https://gitlab.com/{}", repo_path)
     } else {
         url.to_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 name: dependency_name.clone(),
                 version: dependency_version.clone(),
                 url: dependency_url.clone(),
-                hash: hash,
+                hash,
             };
 
             match lock_check(&dependency, true) {
@@ -207,7 +207,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 }
             };
 
-            match add_to_config(&dependency, custom_url, &config_file) {
+            match add_to_config(&dependency, custom_url, &config_file, via_git) {
                 Ok(_) => {}
                 Err(err) => {
                     return Err(SoldeerError { message: err.cause });
@@ -360,7 +360,7 @@ async fn update() -> Result<(), SoldeerError> {
     };
 
     for (index, dependency) in dependencies.iter_mut().enumerate() {
-        dependency.hash = hashes[index].clone();
+        dependency.hash.clone_from(&hashes[index]);
     }
 
     match unzip_dependencies(&dependencies) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,14 @@ use config::{
     add_to_config,
     define_config_file,
 };
+use dependency_downloader::download_dependency;
 use janitor::cleanup_dependency;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use remote::get_dependency_url_remote;
 use std::env;
 use std::path::PathBuf;
+use utils::get_download_tunnel;
 use yansi::Paint;
 
 pub static DEPENDENCY_DIR: Lazy<PathBuf> =
@@ -85,108 +88,103 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             let dependency_version: String =
                 dependency.split('~').collect::<Vec<&str>>()[1].to_string();
             let dependency_url: String;
+
             let mut custom_url = false;
+            let mut via_git = false;
+
             if install.remote_url.is_some() {
                 custom_url = true;
+
                 let remote_url = install.remote_url.unwrap();
-                let mut dependencies: Vec<Dependency> = Vec::new();
+                via_git = get_download_tunnel(&remote_url) == "git";
                 dependency_url = remote_url.clone();
-                let dependency = Dependency {
-                    name: dependency_name.clone(),
-                    version: dependency_version.clone(),
-                    url: dependency_url.clone(),
-                };
-                dependencies.push(dependency.clone());
+            } else {
+                dependency_url =
+                    match get_dependency_url_remote(&dependency_name, &dependency_version).await {
+                        Ok(url) => url,
+                        Err(err) => {
+                            return Err(SoldeerError {
+                                message: format!(
+                                    "Error downloading a dependency {}~{}. Cause {}",
+                                    err.name, err.version, err.cause
+                                ),
+                            });
+                        }
+                    };
+            }
 
-                match lock_check(&dependency, true) {
-                    Ok(dep) => dependencies = dep,
-                    Err(err) => {
-                        return Err(SoldeerError { message: err.cause });
-                    }
+            // retrieve the commit in case it's sent when using git
+            let mut hash = String::new();
+            if via_git && install.commit.is_some() {
+                hash = install.commit.unwrap();
+            } else if !via_git && install.commit.is_some() {
+                return Err(SoldeerError {
+                    message: format!("Error unknown param {}", install.commit.unwrap()),
+                });
+            }
+
+            let mut dependency = Dependency {
+                name: dependency_name.clone(),
+                version: dependency_version.clone(),
+                url: dependency_url.clone(),
+                hash: hash,
+            };
+
+            match lock_check(&dependency, true) {
+                Ok(_) => {}
+                Err(err) => {
+                    return Err(SoldeerError { message: err.cause });
                 }
+            }
 
-                match download_dependencies(&dependencies, false).await {
+            dependency.hash = match download_dependency(&dependency).await {
+                Ok(h) => h,
+                Err(err) => {
+                    return Err(SoldeerError {
+                            message: format!(
+                                "Error downloading a dependency {}~{}. Cause: {}.\nCheck if the dependency name and version are correct.\nIf you are not sure check https://soldeer.xyz.",
+                                err.name, err.version, err.cause
+                            ),
+                        });
+                }
+            };
+
+            match write_lock(&[dependency.clone()], false) {
+                Ok(_) => {}
+                Err(err) => {
+                    return Err(SoldeerError {
+                        message: format!("Error writing the lock: {}", err.cause),
+                    });
+                }
+            }
+
+            if !via_git {
+                match unzip_dependency(&dependency.name, &dependency.version) {
                     Ok(_) => {}
-                    Err(err) => {
+                    Err(err_unzip) => {
+                        match janitor::cleanup_dependency(
+                            &dependency.name,
+                            &dependency.version,
+                            true,
+                            false,
+                        ) {
+                            Ok(_) => {}
+                            Err(err_cleanup) => {
+                                return Err(SoldeerError {
+                                    message: format!(
+                                        "Error cleaning up dependency {}~{}",
+                                        err_cleanup.name, err_cleanup.version
+                                    ),
+                                })
+                            }
+                        }
                         return Err(SoldeerError {
                             message: format!(
                                 "Error downloading a dependency {}~{}",
-                                err.name, err.version
+                                err_unzip.name, err_unzip.version
                             ),
                         });
                     }
-                }
-                match write_lock(&dependencies, false) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        return Err(SoldeerError {
-                            message: format!("Error writing the lock: {}", err.cause),
-                        });
-                    }
-                }
-            } else {
-                let dependency = Dependency {
-                    name: dependency_name.clone(),
-                    version: dependency_version.clone(),
-                    url: String::new(),
-                };
-                let mut dependencies: Vec<Dependency>;
-                match lock_check(&dependency, true) {
-                    Ok(dep) => dependencies = dep,
-                    Err(err) => {
-                        return Err(SoldeerError { message: err.cause });
-                    }
-                }
-
-                match dependency_downloader::download_dependency_remote(
-                    &dependency_name,
-                    &dependency_version,
-                )
-                .await
-                {
-                    Ok(url) => {
-                        dependencies[0].url = url;
-                        dependency_url = dependencies[0].url.clone();
-                    }
-                    Err(err) => {
-                        return Err(SoldeerError {
-                            message: format!(
-                                "Error downloading a dependency {}~{}.\nCheck if the dependency name and version are correct.\nIf you are not sure check https://soldeer.xyz.",
-                                err.name, err.version
-                            ),
-                        });
-                    }
-                }
-
-                match write_lock(&dependencies, false) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        return Err(SoldeerError {
-                            message: format!("Error writing the lock: {}", err.cause),
-                        });
-                    }
-                }
-            }
-            match unzip_dependency(&dependency_name, &dependency_version) {
-                Ok(_) => {}
-                Err(err_unzip) => {
-                    match janitor::cleanup_dependency(&dependency_name, &dependency_version, true) {
-                        Ok(_) => {}
-                        Err(err_cleanup) => {
-                            return Err(SoldeerError {
-                                message: format!(
-                                    "Error cleaning up dependency {}~{}",
-                                    err_cleanup.name, err_cleanup.version
-                                ),
-                            })
-                        }
-                    }
-                    return Err(SoldeerError {
-                        message: format!(
-                            "Error downloading a dependency {}~{}",
-                            err_unzip.name, err_unzip.version
-                        ),
-                    });
                 }
             }
 
@@ -194,7 +192,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 Ok(file) => file,
 
                 Err(_) => {
-                    match cleanup_dependency(&dependency_name, &dependency_version, true) {
+                    match cleanup_dependency(&dependency.name, &dependency.version, true, via_git) {
                         Ok(_) => {
                             return Err(SoldeerError {
                                 message: "Could not define the config file".to_string(),
@@ -209,13 +207,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 }
             };
 
-            match add_to_config(
-                &dependency_name,
-                &dependency_version,
-                &dependency_url,
-                custom_url,
-                &config_file,
-            ) {
+            match add_to_config(&dependency, custom_url, &config_file) {
                 Ok(_) => {}
                 Err(err) => {
                     return Err(SoldeerError { message: err.cause });
@@ -233,7 +225,9 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                     });
                 }
             }
-            match janitor::cleanup_dependency(&dependency_name, &dependency_version, false) {
+
+            match janitor::cleanup_dependency(&dependency_name, &dependency_version, false, via_git)
+            {
                 Ok(_) => {}
                 Err(err) => {
                     return Err(SoldeerError {
@@ -348,13 +342,13 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
 async fn update() -> Result<(), SoldeerError> {
     println!("{}", Paint::green("🦌 Running soldeer update 🦌\n"));
 
-    let dependencies: Vec<Dependency> = match read_config(String::new()).await {
+    let mut dependencies: Vec<Dependency> = match read_config(String::new()).await {
         Ok(dep) => dep,
         Err(err) => return Err(SoldeerError { message: err.cause }),
     };
 
-    match download_dependencies(&dependencies, true).await {
-        Ok(_) => {}
+    let hashes = match download_dependencies(&dependencies, true).await {
+        Ok(h) => h,
         Err(err) => {
             return Err(SoldeerError {
                 message: format!(
@@ -363,6 +357,10 @@ async fn update() -> Result<(), SoldeerError> {
                 ),
             })
         }
+    };
+
+    for (index, dependency) in dependencies.iter_mut().enumerate() {
+        dependency.hash = hashes[index].clone();
     }
 
     match unzip_dependencies(&dependencies) {
@@ -491,6 +489,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: None,
             remote_url: None,
+            commit: None,
         });
 
         match run(command) {
@@ -503,9 +502,9 @@ libs = ["dependencies"]
 
         let mut path_dependency = DEPENDENCY_DIR.join("@gearbox-protocol-periphery-v3-1.6.1");
 
-        assert!(Path::new(&path_dependency).exists());
+        assert!(path_dependency.exists());
         path_dependency = DEPENDENCY_DIR.join("@openzeppelin-contracts-5.0.2");
-        assert!(Path::new(&path_dependency).exists());
+        assert!(path_dependency.exists());
         clean_test_env(target_config);
     }
 
@@ -537,6 +536,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: None,
             remote_url: None,
+            commit: None,
         });
 
         match run(command) {
@@ -549,7 +549,7 @@ libs = ["dependencies"]
 
         let path_dependency = DEPENDENCY_DIR.join("@tt-1.6.1");
 
-        assert!(Path::new(&path_dependency).exists());
+        assert!(path_dependency.exists());
         clean_test_env(target_config);
     }
 
@@ -590,7 +590,63 @@ libs = ["dependencies"]
 
         let path_dependency = DEPENDENCY_DIR.join("@tt-1.6.1");
 
-        assert!(Path::new(&path_dependency).exists());
+        assert!(path_dependency.exists());
+        clean_test_env(target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn soldeer_update_dependencies_fails_when_one_dependency_fails() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"@gearbox-protocol-periphery-v3" = "1.6.1"
+"@openzeppelin-contracts" = "5.0.2"   
+"will-not-fail" = {version = "1", url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/v1_9_0_03-07-2024_14:44:57_forge-std-v1.9.0.zip"}  
+"will-fail" = {version = "1", url="https://will-not-work"}
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: None,
+            remote_url: None,
+            commit: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                clean_test_env(target_config.clone());
+                assert_eq!(
+                    err,
+                    SoldeerError {
+                        message: "Error downloading a dependency will-fail~https://will-not-work"
+                            .to_string()
+                    }
+                )
+            }
+        }
+
+        let mut path_dependency = DEPENDENCY_DIR.join("@gearbox-protocol-periphery-v3-1.6.1");
+
+        assert!(!path_dependency.exists());
+        path_dependency = DEPENDENCY_DIR.join("@openzeppelin-contracts-5.0.2");
+        assert!(!path_dependency.exists());
         clean_test_env(target_config);
     }
 
@@ -630,7 +686,7 @@ libs = ["dependencies"]
         let archive = File::open(path_dependency.join("custom_dry_run.zip"));
         let archive = ZipArchive::new(archive.unwrap());
 
-        assert!(Path::new(&path_dependency).exists());
+        assert!(path_dependency.exists());
         assert_eq!(archive.unwrap().len(), 2);
 
         let _ = remove_dir_all(path_dependency);
@@ -719,7 +775,10 @@ libs = ["dependencies"]
     fn push_skips_warning_on_sensitive_files() {
         let _ = remove_dir_all(DEPENDENCY_DIR.clone());
         let _ = remove_file(LOCK_FILE.clone());
-        let test_dir = env::current_dir().unwrap().join("test_push_skip_sensitive");
+        let test_dir = env::current_dir()
+            .unwrap()
+            .join("test")
+            .join("test_push_skip_sensitive");
 
         // Create test directory
         if !test_dir.exists() {
@@ -767,6 +826,297 @@ libs = ["dependencies"]
         // Clean up
         let _ = remove_file(&env_file_path);
         let _ = remove_dir_all(&test_dir);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_remote_url() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir()
+            .unwrap()
+            .join("test")
+            .join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Option::None,
+            commit: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(target_config.clone());
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let path_dependency = DEPENDENCY_DIR
+            .join("forge-std-1.9.1")
+            .join("src")
+            .join("Test.sol");
+        assert!(path_dependency.exists());
+        clean_test_env(target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_custom_url_chooses_http() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir()
+            .unwrap()
+            .join("test")
+            .join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Some("https://soldeer-revisions.s3.amazonaws.com/forge-std/v1_9_0_03-07-2024_14:44:57_forge-std-v1.9.0.zip".to_string()),
+            commit: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(target_config.clone());
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let path_dependency = DEPENDENCY_DIR
+            .join("forge-std-1.9.1")
+            .join("src")
+            .join("Test.sol");
+        assert!(path_dependency.exists());
+        clean_test_env(target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_custom_git_httpurl_chooses_git() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir()
+            .unwrap()
+            .join("test")
+            .join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Some("https://github.com/foundry-rs/forge-std.git".to_string()),
+            commit: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(target_config.clone());
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let path_dependency = DEPENDENCY_DIR
+            .join("forge-std-1.9.1")
+            .join("src")
+            .join("Test.sol");
+        assert!(path_dependency.exists());
+        clean_test_env(target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_custom_git_giturl_chooses_git() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir()
+            .unwrap()
+            .join("test")
+            .join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
+            commit: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(target_config.clone());
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let path_dependency = DEPENDENCY_DIR
+            .join("forge-std-1.9.1")
+            .join("src")
+            .join("Test.sol");
+        assert!(path_dependency.exists());
+        clean_test_env(target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_custom_git_giturl_custom_commit() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir()
+            .unwrap()
+            .join("test")
+            .join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
+            commit: Some("3778c3cb8e4244cb5a1c3ef3ce1c71a3683e324a".to_string()),
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(target_config.clone());
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let mut path_dependency = DEPENDENCY_DIR
+            .join("forge-std-1.9.1")
+            .join("src")
+            .join("mocks")
+            .join("MockERC721.sol");
+        assert!(!path_dependency.exists()); // this should not exists at that commit
+        path_dependency = DEPENDENCY_DIR
+            .join("forge-std-1.9.1")
+            .join("src")
+            .join("Test.sol");
+        assert!(path_dependency.exists()); // this should exists at that commit
+        clean_test_env(target_config);
     }
 
     fn create_random_file(target_dir: &Path, extension: String) -> String {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -132,7 +132,6 @@ pub fn write_lock(dependencies: &[Dependency], clean: bool) -> Result<(), LockEr
 
     let mut new_lock_entries: String = String::new();
     dependencies.iter().for_each(|dependency| {
-        let hash = sha256_digest(&dependency.name, &dependency.version);
         new_lock_entries.push_str(&format!(
             r#"
 [[dependencies]]
@@ -141,7 +140,7 @@ version = "{}"
 source = "{}"
 checksum = "{}"
 "#,
-            dependency.name, dependency.version, dependency.url, hash
+            dependency.name, dependency.version, dependency.url, dependency.hash
         ));
         println!(
             "{}",
@@ -200,22 +199,6 @@ checksum = "{}"
     Ok(())
 }
 
-#[cfg(not(test))]
-fn sha256_digest(dependency_name: &str, dependency_version: &str) -> String {
-    let bytes = std::fs::read(
-        get_current_working_dir()
-            .join("dependencies")
-            .join(format!("{}-{}.zip", dependency_name, dependency_version)),
-    )
-    .unwrap(); // Vec<u8>
-    sha256::digest(bytes)
-}
-
-#[cfg(test)]
-fn sha256_digest(_dependency_name: &str, _dependency_version: &str) -> String {
-    "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,6 +245,7 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
+            hash: String::new()
         };
 
         assert!(
@@ -278,6 +262,7 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
+            hash: String::new(),
         };
 
         assert!(lock_check(&dependency, true).is_err_and(|e| {
@@ -293,6 +278,7 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             name: "@openzeppelin-contracts".to_string(),
             version: "2.5.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip".to_string(),
+            hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
         };
         let dependencies = vec![dependency.clone()];
         write_lock(&dependencies, false).unwrap();
@@ -326,6 +312,7 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             name: "@openzeppelin-contracts-2".to_string(),
             version: "2.6.0".to_string(),
             url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.6.0.zip".to_string(),
+            hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
         };
         dependencies.push(dependency.clone());
         write_lock(&dependencies, false).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use simple_home_dir::home_dir;
 use std::env;
 use std::fs::{
@@ -177,4 +178,33 @@ pub fn prompt_user_for_confirmation() -> bool {
     std::io::stdin().read_line(&mut input).unwrap();
     let input = input.trim().to_lowercase();
     input == "y" || input == "yes"
+}
+
+pub fn get_download_tunnel(dependency_url: &str) -> String {
+    let pattern1 = r"^(git@github\.com|git@gitlab)";
+    let pattern2 = r"^(https://github\.com|https://gitlab\.com)";
+    let re1 = Regex::new(pattern1).unwrap();
+    let re2 = Regex::new(pattern2).unwrap();
+    if re1.is_match(dependency_url)
+        || (re2.is_match(dependency_url) && dependency_url.ends_with(".git"))
+    {
+        return "git".to_string();
+    }
+    "http".to_string()
+}
+
+#[cfg(not(test))]
+pub fn sha256_digest(dependency_name: &str, dependency_version: &str) -> String {
+    use crate::DEPENDENCY_DIR;
+
+    let bytes = std::fs::read(
+        DEPENDENCY_DIR.join(format!("{}-{}.zip", dependency_name, dependency_version)),
+    )
+    .unwrap(); // Vec<u8>
+    sha256::digest(bytes)
+}
+
+#[cfg(test)]
+pub fn sha256_digest(_dependency_name: &str, _dependency_version: &str) -> String {
+    "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
 }

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -36,6 +36,7 @@ fn soldeer_install_valid_dependency() {
     let command = Subcommands::Install(Install {
         dependency: Some("forge-std~1.8.2".to_string()),
         remote_url: None,
+        commit: None,
     });
 
     match soldeer::run(command) {
@@ -46,10 +47,10 @@ fn soldeer_install_valid_dependency() {
     }
 
     let path_dependency = DEPENDENCY_DIR.join("forge-std-1.8.2");
-    assert!(Path::new(&path_dependency).exists());
+    assert!(path_dependency.exists());
     let test_contract = r#"
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity >=  0.8.20;
 
 contract Increment {
     uint256 i;
@@ -62,7 +63,7 @@ contract Increment {
 
     let test = r#"
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity >= 0.8.20;
 import "../src/Increment.sol";
 import "@forge-std-1.8.2/src/Test.sol";
 
@@ -125,7 +126,14 @@ contract TestSoldeer is Test {
         .output()
         .expect("failed to execute process");
 
-    assert!(String::from_utf8(output.stdout).unwrap().contains("[PASS]"));
+    let passed = String::from_utf8(output.stdout).unwrap().contains("[PASS]");
+    if !passed {
+        println!(
+            "This will fail with: {:?}",
+            String::from_utf8(output.stderr).unwrap()
+        );
+    }
+    assert!(passed);
     clean_test_env(&test_project);
 }
 
@@ -135,6 +143,7 @@ fn soldeer_install_invalid_dependency() {
     let command = Subcommands::Install(Install {
         dependency: Some("forge-std".to_string()),
         remote_url: None,
+        commit: None,
     });
 
     match soldeer::run(command) {
@@ -154,8 +163,8 @@ fn soldeer_install_invalid_dependency() {
     let path_dependency = DEPENDENCY_DIR.join("forge-std");
     let path_zip = DEPENDENCY_DIR.join("forge-std.zip");
 
-    assert!(!Path::new(&path_zip).exists());
-    assert!(!Path::new(&path_dependency).exists());
+    assert!(!path_zip.exists());
+    assert!(!path_dependency.exists());
 }
 
 fn clean_test_env(test_project: &PathBuf) {


### PR DESCRIPTION
Now we can use git to pull dependencies. It supports github and gitlab

Example:
`soldeer install test-project~v1 git@github.com:test/test.git`
`soldeer install test-project~v1 git@gitlab.com:test/test.git`

`soldeer install test-project~v1 https://github.com/test/test.git`
`soldeer install test-project~v1 https://gitlab.com/test/test.git`

Or using custom commit hashes
`soldeer install test-project~v1 git@github.com:test/test.git 345e611cd84bfb4e62c583fa1886c1928bc1a464`
