### PR TITLE
Rewritten git feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,21 +563,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "git2"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,46 +846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.17.0+1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,24 +961,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1656,7 +1583,6 @@ dependencies = [
  "email-address-parser",
  "env_logger",
  "futures",
- "git2",
  "mockito",
  "once_cell",
  "rand",
@@ -1977,12 +1903,6 @@ dependencies = [
  "getrandom",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ chrono = {version = "0.4.38", default-features = false, features = [
 clap = {version = "4.5.9", features = ["derive"]}
 email-address-parser = "2.0.0"
 futures = "0.3.30"
-git2 = "0.19.0"
 once_cell = "1.19"
 regex = "1.10.5"
 reqwest = {version = "0.12.5", features = [

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -27,7 +27,7 @@ pub enum Subcommands {
     Example from remote repository: soldeer install @openzeppelin-contracts~2.3.0 
     Example custom url: soldeer install @openzeppelin-contracts~2.3.0 https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v5.0.2.zip
     Example git: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git
-    Example git with specified commit: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git 05f218fb6617932e56bf5388c3b389c3028a7b73\n",
+    Example git with specified commit: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73\n",
     after_help = "For more information, read the README.md",
     override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
 )]
@@ -36,8 +36,8 @@ pub struct Install {
     pub dependency: Option<String>,
     #[clap(required = false)]
     pub remote_url: Option<String>,
-    #[clap(required = false)]
-    pub commit: Option<String>,
+    #[arg(long, value_parser = clap::value_parser!(String))]
+    pub rev: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,11 +115,11 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
 
             // retrieve the commit in case it's sent when using git
             let mut hash = String::new();
-            if via_git && install.commit.is_some() {
-                hash = install.commit.unwrap();
-            } else if !via_git && install.commit.is_some() {
+            if via_git && install.rev.is_some() {
+                hash = install.rev.unwrap();
+            } else if !via_git && install.rev.is_some() {
                 return Err(SoldeerError {
-                    message: format!("Error unknown param {}", install.commit.unwrap()),
+                    message: format!("Error unknown param {}", install.rev.unwrap()),
                 });
             }
 
@@ -141,11 +141,11 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 Ok(h) => h,
                 Err(err) => {
                     return Err(SoldeerError {
-                            message: format!(
-                                "Error downloading a dependency {}~{}. Cause: {}.\nCheck if the dependency name and version are correct.\nIf you are not sure check https://soldeer.xyz.",
-                                err.name, err.version, err.cause
-                            ),
-                        });
+                        message: format!(
+                            "Error downloading a dependency {}~{}. Cause: {}",
+                            err.name, err.version, err.cause
+                        ),
+                    });
                 }
             };
 
@@ -352,8 +352,8 @@ async fn update() -> Result<(), SoldeerError> {
         Err(err) => {
             return Err(SoldeerError {
                 message: format!(
-                    "Error downloading a dependency {}~{}",
-                    err.name, err.version
+                    "Error downloading a dependency {}~{}. Cause: {}",
+                    err.name, err.version, err.cause
                 ),
             })
         }
@@ -489,7 +489,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: None,
             remote_url: None,
-            commit: None,
+            rev: None,
         });
 
         match run(command) {
@@ -536,7 +536,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: None,
             remote_url: None,
-            commit: None,
+            rev: None,
         });
 
         match run(command) {
@@ -596,6 +596,63 @@ libs = ["dependencies"]
 
     #[test]
     #[serial]
+    fn soldeer_update_with_git_and_http_success() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"@dep1" = {version = "1", url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/3_3_0-rc_2_22-01-2024_13:12:57_contracts.zip"}
+"@dep2" = {version = "2", git = "git@gitlab.com:mario4582928/Mario.git", rev="22868f426bd4dd0e682b5ec5f9bd55507664240c" }
+"@dep3" = {version = "3.3", git = "git@gitlab.com:mario4582928/Mario.git", rev="7a0663eaf7488732f39550be655bad6694974cb3" }
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Update(Update {});
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {:?}", err);
+                clean_test_env(target_config.clone());
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        // http dependency should be there
+        let path_dependency = DEPENDENCY_DIR
+            .join("@dep1-1")
+            .join("token")
+            .join("ERC20")
+            .join("ERC20.sol");
+        assert!(path_dependency.exists());
+
+        // git dependency should be there without specified revision
+        let path_dependency = DEPENDENCY_DIR.join("@dep2-2").join("JustATest3.md");
+        assert!(path_dependency.exists());
+
+        // git dependency should be there with specified revision
+        let path_dependency = DEPENDENCY_DIR.join("@dep3-3.3").join("JustATest2.md");
+        assert!(path_dependency.exists());
+
+        clean_test_env(target_config);
+    }
+
+    #[test]
+    #[serial]
     fn soldeer_update_dependencies_fails_when_one_dependency_fails() {
         let _ = remove_dir_all(DEPENDENCY_DIR.clone());
         let _ = remove_file(LOCK_FILE.clone());
@@ -625,7 +682,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: None,
             remote_url: None,
-            commit: None,
+            rev: None,
         });
 
         match run(command) {
@@ -635,7 +692,7 @@ libs = ["dependencies"]
                 assert_eq!(
                     err,
                     SoldeerError {
-                        message: "Error downloading a dependency will-fail~https://will-not-work"
+                        message: "Error downloading a dependency will-fail~1. Cause: Unknown error: Error { kind: Connect, source: Some(ConnectError(\"dns error\", Custom { kind: Uncategorized, error: \"failed to lookup address information: nodename nor servname provided, or not known\" })) }"
                             .to_string()
                     }
                 )
@@ -865,7 +922,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Option::None,
-            commit: None,
+            rev: None,
         });
 
         match run(command) {
@@ -922,7 +979,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("https://soldeer-revisions.s3.amazonaws.com/forge-std/v1_9_0_03-07-2024_14:44:57_forge-std-v1.9.0.zip".to_string()),
-            commit: None,
+            rev: None,
         });
 
         match run(command) {
@@ -979,7 +1036,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("https://github.com/foundry-rs/forge-std.git".to_string()),
-            commit: None,
+            rev: None,
         });
 
         match run(command) {
@@ -1036,7 +1093,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
-            commit: None,
+            rev: None,
         });
 
         match run(command) {
@@ -1093,7 +1150,7 @@ libs = ["dependencies"]
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
-            commit: Some("3778c3cb8e4244cb5a1c3ef3ce1c71a3683e324a".to_string()),
+            rev: Some("3778c3cb8e4244cb5a1c3ef3ce1c71a3683e324a".to_string()),
         });
 
         match run(command) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,13 +689,10 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 clean_test_env(target_config.clone());
-                assert_eq!(
-                    err,
-                    SoldeerError {
-                        message: "Error downloading a dependency will-fail~1. Cause: Unknown error: Error { kind: Connect, source: Some(ConnectError(\"dns error\", Custom { kind: Uncategorized, error: \"failed to lookup address information: nodename nor servname provided, or not known\" })) }"
-                            .to_string()
-                    }
-                )
+                // can not generalize as diff systems return various dns errors
+                assert!(err
+                    .message
+                    .contains("Error downloading a dependency will-fail~1"))
             }
         }
 

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -36,7 +36,7 @@ fn soldeer_install_valid_dependency() {
     let command = Subcommands::Install(Install {
         dependency: Some("forge-std~1.8.2".to_string()),
         remote_url: None,
-        commit: None,
+        rev: None,
     });
 
     match soldeer::run(command) {
@@ -143,7 +143,7 @@ fn soldeer_install_invalid_dependency() {
     let command = Subcommands::Install(Install {
         dependency: Some("forge-std".to_string()),
         remote_url: None,
-        commit: None,
+        rev: None,
     });
 
     match soldeer::run(command) {


### PR DESCRIPTION
I rewrote the git feature to mimic the rust dependency git/rev pattern, also removed the git2 dependency, and just used the CLI.

In the config we will see
```toml
[dependencies]
"dep1" = { version="1", git = "git@github.com/path.git", rev = "23d4edsadsa4s44s4" }
```
while the approach of using the central repository will remain
```toml
[dependencies]
"dep1" = { version="1", url = "https://path" }
```
Now we can use git to pull dependencies. It supports github and gitlab

Example:
```bash
soldeer install test-project~v1 git@github.com:test/test.git
soldeer install test-project~v1 git@gitlab.com:test/test.git
```
```bash
soldeer install test-project~v1 https://github.com/test/test.git
soldeer install test-project~v1 https://gitlab.com/test/test.git
```
Or using custom commit hashes
```bash
soldeer install test-project~v1 git@github.com:test/test.git --rev 345e611cd84bfb4e62c583fa1886c1928bc1a464
```