### PR TITLE
style(fmt): update formatter configuration and improve consistency

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,11 @@
-force_multiline_blocks = true
-imports_indent = "Block"
-imports_layout = "Vertical"
+reorder_imports = true
+imports_granularity = "Crate"
+use_small_heuristics = "Max"
+comment_width = 100
+wrap_comments = true
+binop_separator = "Back"
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true
+format_code_in_doc_comments = true
+doc_comment_code_block_width = 100

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,25 +1,14 @@
-use crate::errors::LoginError;
-use crate::utils::{
-    define_security_file_location,
-    get_base_url,
-    read_file,
+use crate::{
+    errors::LoginError,
+    utils::{define_security_file_location, get_base_url, read_file},
 };
-use email_address_parser::{
-    EmailAddress,
-    ParsingOptions,
-};
+use email_address_parser::{EmailAddress, ParsingOptions};
 use reqwest::Client;
 use rpassword::read_password;
-use serde_derive::{
-    Deserialize,
-    Serialize,
-};
+use serde_derive::{Deserialize, Serialize};
 use std::{
     fs::OpenOptions,
-    io::{
-        self,
-        Write,
-    },
+    io::{self, Write},
 };
 use yansi::Paint;
 
@@ -40,9 +29,7 @@ pub async fn login() -> Result<(), LoginError> {
     std::io::stdout().flush().unwrap();
     let mut email = String::new();
     if io::stdin().read_line(&mut email).is_err() {
-        return Err(LoginError {
-            cause: "Invalid email".to_string(),
-        });
+        return Err(LoginError { cause: "Invalid email".to_string() });
     }
     email = match check_email(email) {
         Ok(e) => e,
@@ -63,15 +50,11 @@ pub fn get_token() -> Result<String, LoginError> {
     let security_file = define_security_file_location();
     let jwt = read_file(security_file);
     match jwt {
-        Ok(token) => {
-            Ok(String::from_utf8(token)
-                .expect("You are not logged in. Please login using the 'soldeer login' command"))
-        }
-        Err(_) => {
-            Err(LoginError {
-                cause: "You are not logged in. Please login using the 'login' command".to_string(),
-            })
-        }
+        Ok(token) => Ok(String::from_utf8(token)
+            .expect("You are not logged in. Please login using the 'soldeer login' command")),
+        Err(_) => Err(LoginError {
+            cause: "You are not logged in. Please login using the 'login' command".to_string(),
+        }),
     }
 }
 
@@ -81,9 +64,7 @@ fn check_email(email_str: String) -> Result<String, LoginError> {
     let email: Option<EmailAddress> =
         EmailAddress::parse(&email_str, Some(ParsingOptions::default()));
     if email.is_none() {
-        Err(LoginError {
-            cause: "Invalid email".to_string(),
-        })
+        Err(LoginError { cause: "Invalid email".to_string() })
     } else {
         Ok(email_str)
     }
@@ -117,10 +98,7 @@ async fn execute_login(login: Login) -> Result<(), LoginError> {
                     ),
                 });
             }
-            println!(
-                "{}",
-                Paint::green(&format!("Login details saved in: {:?}", &security_file))
-            );
+            println!("{}", Paint::green(&format!("Login details saved in: {:?}", &security_file)));
 
             return Ok(());
         } else if response.status().as_u16() == 401 {
@@ -137,17 +115,12 @@ async fn execute_login(login: Login) -> Result<(), LoginError> {
         }
     }
 
-    Err(LoginError {
-        cause: format!("Authentication failed. Unknown error.{:?}", login_response),
-    })
+    Err(LoginError { cause: format!("Authentication failed. Unknown error.{:?}", login_response) })
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        env,
-        fs::remove_file,
-    };
+    use std::{env, fs::remove_file};
 
     use serial_test::serial;
 
@@ -163,9 +136,7 @@ mod tests {
 
         assert_eq!(check_email(valid_email.clone()).unwrap(), valid_email);
 
-        let expected_error = LoginError {
-            cause: "Invalid email".to_string(),
-        };
+        let expected_error = LoginError { cause: "Invalid email".to_string() };
         assert_eq!(check_email(invalid_email).err().unwrap(), expected_error);
     }
 
@@ -267,9 +238,8 @@ mod tests {
         {
             Ok(_) => {}
             Err(err) => {
-                let expected_error = LoginError {
-                    cause: "Authentication failed. Server response: 500".to_string(),
-                };
+                let expected_error =
+                    LoginError { cause: "Authentication failed. Server response: 500".to_string() };
                 assert_eq!(err, expected_error);
             }
         };

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -120,13 +120,10 @@ async fn execute_login(login: Login) -> Result<(), LoginError> {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, fs::remove_file};
-
-    use serial_test::serial;
-
-    use crate::utils::read_file_to_string;
-
     use super::*;
+    use crate::utils::read_file_to_string;
+    use serial_test::serial;
+    use std::{env, fs::remove_file};
 
     #[test]
     #[serial]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,6 +14,7 @@ pub enum Subcommands {
     Update(Update),
     Login(Login),
     Push(Push),
+    Uninstall(Uninstall),
     VersionDryRun(VersionDryRun),
 }
 
@@ -70,4 +71,15 @@ pub struct Push {
     pub dry_run: Option<bool>,
     #[arg(long, value_parser = clap::value_parser!(bool))]
     pub skip_warnings: Option<bool>,
+}
+
+#[derive(Debug, Clone, Parser)]
+#[clap(
+    about = "Uninstall a dependency. soldeer uninstall <DEPENDENCY>",
+    after_help = "For more information, read the README.md",
+    override_usage = "soldeer uninstall <DEPENDENCY>"
+)]
+pub struct Uninstall {
+    #[clap(required = true)]
+    pub dependency: String,
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,4 @@
-use clap::{
-    Parser,
-    Subcommand,
-};
+use clap::{Parser, Subcommand};
 
 /// A minimal solidity dependency manager.
 #[derive(Parser, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -298,6 +298,54 @@ pub fn get_foundry_setup() -> Result<Vec<bool>, ConfigError> {
     Ok(vec![data.remappings.get("enabled").unwrap().as_bool().unwrap()])
 }
 
+pub fn delete_config(
+    dependency_name: &String,
+    config_file: &str,
+) -> Result<Dependency, ConfigError> {
+    println!(
+        "{}",
+        Paint::green(&format!("Removing the dependency {} from the config file", dependency_name))
+    );
+
+    let contents = read_file_to_string(&String::from(config_file));
+    let mut doc: DocumentMut = contents.parse::<DocumentMut>().expect("invalid doc");
+
+    if !doc.contains_table("dependencies") {
+        return Err(ConfigError {
+            cause: format!("Could not read the config file {}", config_file),
+        });
+    }
+
+    let item_removed = doc["dependencies"].as_table_mut().unwrap().remove(dependency_name);
+
+    if item_removed.is_none() {
+        return Err(ConfigError {
+            cause: format!("The dependency {} does not exists in the config file", dependency_name),
+        });
+    }
+
+    let dependency = Dependency {
+        name: dependency_name.clone(),
+        version: item_removed
+            .unwrap()
+            .as_value()
+            .unwrap()
+            .to_string()
+            .replace("\"", "")
+            .trim()
+            .to_string(),
+        hash: "".to_string(),
+        url: "".to_string(),
+    };
+
+    let mut file: std::fs::File =
+        fs::OpenOptions::new().write(true).append(false).truncate(true).open(config_file).unwrap();
+    if let Err(e) = write!(file, "{}", doc) {
+        return Err(ConfigError { cause: format!("Couldn't write to the config file {}", e) });
+    }
+    Ok(dependency)
+}
+
 fn create_example_config(option: &str) -> Result<String, ConfigError> {
     let config_file: &str;
     let content: &str;
@@ -352,11 +400,10 @@ mod tests {
         path::PathBuf,
     };
 
+    use super::*;
     use crate::{config::Dependency, errors::ConfigError, utils::get_current_working_dir};
     use rand::{distributions::Alphanumeric, Rng};
-    use serial_test::serial; // 0.8
-
-    use super::*;
+    use serial_test::serial;
 
     #[tokio::test] // check dependencies as {version = "1.1.1"}
     #[serial]
@@ -1333,6 +1380,144 @@ gas_reports = ['*']
 [dependencies]
 dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 "#;
+
+        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+
+        let _ = remove_file(target_config);
+        Ok(())
+    }
+
+    #[test]
+    fn remove_from_the_config_single() -> Result<(), ConfigError> {
+        let mut content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        let dependency = Dependency {
+            name: "dep1".to_string(),
+            version: "1.0.0".to_string(),
+            url: "http://custom_url.com/custom.zip".to_string(),
+            hash: String::new(),
+        };
+
+        delete_config(&dependency.name, target_config.to_str().unwrap()).unwrap();
+        content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+"#;
+
+        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+
+        let _ = remove_file(target_config);
+        Ok(())
+    }
+
+    #[test]
+    fn remove_from_the_config_multiple() -> Result<(), ConfigError> {
+        let mut content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+dep3 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
+dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
+dep2 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        let dependency = Dependency {
+            name: "dep1".to_string(),
+            version: "1.0.0".to_string(),
+            url: "http://custom_url.com/custom.zip".to_string(),
+            hash: String::new(),
+        };
+
+        delete_config(&dependency.name, target_config.to_str().unwrap()).unwrap();
+        content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+dep3 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
+dep2 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
+"#;
+
+        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+
+        let _ = remove_file(target_config);
+        Ok(())
+    }
+
+    #[test]
+    fn remove_config_nonexistent_fails() -> Result<(), ConfigError> {
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        match delete_config(&"dep2".to_string(), target_config.to_str().unwrap()) {
+            Ok(_) => {
+                assert_eq!("Invalid State", "");
+            }
+            Err(err) => {
+                assert_eq!(
+                    err,
+                    ConfigError {
+                        cause: "The dependency dep2 does not exists in the config file".to_string()
+                    }
+                )
+            }
+        }
 
         assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -346,54 +346,6 @@ pub fn delete_config(
     Ok(dependency)
 }
 
-pub fn delete_config(
-    dependency_name: &String,
-    config_file: &str,
-) -> Result<Dependency, ConfigError> {
-    println!(
-        "{}",
-        Paint::green(&format!("Removing the dependency {} from the config file", dependency_name))
-    );
-
-    let contents = read_file_to_string(&String::from(config_file));
-    let mut doc: DocumentMut = contents.parse::<DocumentMut>().expect("invalid doc");
-
-    if !doc.contains_table("dependencies") {
-        return Err(ConfigError {
-            cause: format!("Could not read the config file {}", config_file),
-        });
-    }
-
-    let item_removed = doc["dependencies"].as_table_mut().unwrap().remove(dependency_name);
-
-    if item_removed.is_none() {
-        return Err(ConfigError {
-            cause: format!("The dependency {} does not exists in the config file", dependency_name),
-        });
-    }
-
-    let dependency = Dependency {
-        name: dependency_name.clone(),
-        version: item_removed
-            .unwrap()
-            .as_value()
-            .unwrap()
-            .to_string()
-            .replace("\"", "")
-            .trim()
-            .to_string(),
-        hash: "".to_string(),
-        url: "".to_string(),
-    };
-
-    let mut file: std::fs::File =
-        fs::OpenOptions::new().write(true).append(false).truncate(true).open(config_file).unwrap();
-    if let Err(e) = write!(file, "{}", doc) {
-        return Err(ConfigError { cause: format!("Couldn't write to the config file {}", e) });
-    }
-    Ok(dependency)
-}
-
 fn create_example_config(option: &str) -> Result<String, ConfigError> {
     let config_file: &str;
     let content: &str;
@@ -439,6 +391,10 @@ enabled = true
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::{config::Dependency, errors::ConfigError, utils::get_current_working_dir};
+    use rand::{distributions::Alphanumeric, Rng};
+    use serial_test::serial;
     use std::{
         env,
         fs::{
@@ -447,11 +403,6 @@ mod tests {
         io::Write,
         path::PathBuf,
     };
-
-    use super::*;
-    use crate::{config::Dependency, errors::ConfigError, utils::get_current_working_dir};
-    use rand::{distributions::Alphanumeric, Rng};
-    use serial_test::serial;
 
     #[tokio::test] // check dependencies as {version = "1.1.1"}
     #[serial]
@@ -1428,144 +1379,6 @@ gas_reports = ['*']
 [dependencies]
 dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 "#;
-
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
-
-        let _ = remove_file(target_config);
-        Ok(())
-    }
-
-    #[test]
-    fn remove_from_the_config_single() -> Result<(), ConfigError> {
-        let mut content = r#"
-# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
-
-[profile.default]
-script = "script"
-solc = "0.8.26"
-src = "src"
-test = "test"
-libs = ["dependencies"]
-
-[dependencies]
-dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
-"#;
-
-        let target_config = define_config(true);
-
-        write_to_config(&target_config, content);
-
-        let dependency = Dependency {
-            name: "dep1".to_string(),
-            version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
-
-        delete_config(&dependency.name, target_config.to_str().unwrap()).unwrap();
-        content = r#"
-# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
-
-[profile.default]
-script = "script"
-solc = "0.8.26"
-src = "src"
-test = "test"
-libs = ["dependencies"]
-
-[dependencies]
-"#;
-
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
-
-        let _ = remove_file(target_config);
-        Ok(())
-    }
-
-    #[test]
-    fn remove_from_the_config_multiple() -> Result<(), ConfigError> {
-        let mut content = r#"
-# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
-
-[profile.default]
-script = "script"
-solc = "0.8.26"
-src = "src"
-test = "test"
-libs = ["dependencies"]
-
-[dependencies]
-dep3 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
-dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
-dep2 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
-"#;
-
-        let target_config = define_config(true);
-
-        write_to_config(&target_config, content);
-
-        let dependency = Dependency {
-            name: "dep1".to_string(),
-            version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
-
-        delete_config(&dependency.name, target_config.to_str().unwrap()).unwrap();
-        content = r#"
-# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
-
-[profile.default]
-script = "script"
-solc = "0.8.26"
-src = "src"
-test = "test"
-libs = ["dependencies"]
-
-[dependencies]
-dep3 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
-dep2 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
-"#;
-
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
-
-        let _ = remove_file(target_config);
-        Ok(())
-    }
-
-    #[test]
-    fn remove_config_nonexistent_fails() -> Result<(), ConfigError> {
-        let content = r#"
-# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
-
-[profile.default]
-script = "script"
-solc = "0.8.26"
-src = "src"
-test = "test"
-libs = ["dependencies"]
-
-[dependencies]
-dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
-"#;
-
-        let target_config = define_config(true);
-
-        write_to_config(&target_config, content);
-
-        match delete_config(&"dep2".to_string(), target_config.to_str().unwrap()) {
-            Ok(_) => {
-                assert_eq!("Invalid State", "");
-            }
-            Err(err) => {
-                assert_eq!(
-                    err,
-                    ConfigError {
-                        cause: "The dependency dep2 does not exists in the config file".to_string()
-                    }
-                )
-            }
-        }
 
         assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
 

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::Dependency,
-    errors::{DownloadError, UnzippingError},
+    errors::{DependencyError, DownloadError, UnzippingError},
     utils::{get_download_tunnel, read_file, sha256_digest},
     DEPENDENCY_DIR,
 };
@@ -307,6 +307,12 @@ async fn download_via_http(
             });
         }
     };
+    Ok(())
+}
+
+pub fn delete_dependency_files(dependency: &Dependency) -> Result<(), DependencyError> {
+    let _ =
+        remove_dir_all(DEPENDENCY_DIR.join(format!("{}-{}", dependency.name, dependency.version)));
     Ok(())
 }
 
@@ -762,5 +768,30 @@ mod tests {
             transform_git_to_http("https://gitlab.com/mario4582928/Mario.git"),
             "https://gitlab.com/mario4582928/Mario.git"
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn remove_one_dependency() {
+        let mut dependencies: Vec<Dependency> = Vec::new();
+
+        let dependency = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.3.0".to_string(),
+            url: "git@github.com:transmissions11/solmate.git".to_string(),
+            hash: String::new(),
+        };
+        dependencies.push(dependency.clone());
+
+        match download_dependencies(&dependencies, false).await {
+            Ok(_) => {}
+            Err(_) => {
+                assert_eq!("Invalid state", "");
+            }
+        }
+        let _ = delete_dependency_files(&dependency);
+        assert!(!DEPENDENCY_DIR
+            .join(format!("{}~{}", dependency.name, dependency.version))
+            .exists());
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -126,3 +126,30 @@ impl ConfigError {
         ConfigError { cause: cause.to_string() }
     }
 }
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DependencyError {
+    pub name: String,
+    pub version: String,
+    pub cause: String,
+}
+
+impl fmt::Display for DependencyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "dependency operation failed for {}~{}",
+            &self.name, &self.version
+        )
+    }
+}
+
+impl DependencyError {
+    pub fn new(name: &str, version: &str, cause: &str) -> DependencyError {
+        DependencyError {
+            name: name.to_string(),
+            version: version.to_string(),
+            cause: cause.to_string(),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -136,38 +136,7 @@ pub struct DependencyError {
 
 impl fmt::Display for DependencyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "dependency operation failed for {}~{}",
-            &self.name, &self.version
-        )
-    }
-}
-
-impl DependencyError {
-    pub fn new(name: &str, version: &str, cause: &str) -> DependencyError {
-        DependencyError {
-            name: name.to_string(),
-            version: version.to_string(),
-            cause: cause.to_string(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct DependencyError {
-    pub name: String,
-    pub version: String,
-    pub cause: String,
-}
-
-impl fmt::Display for DependencyError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "dependency operation failed for {}~{}",
-            &self.name, &self.version
-        )
+        write!(f, "dependency operation failed for {}~{}", &self.name, &self.version)
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,10 +19,7 @@ pub struct MissingDependencies {
 
 impl MissingDependencies {
     pub fn new(name: &str, version: &str) -> MissingDependencies {
-        MissingDependencies {
-            name: name.to_string(),
-            version: version.to_string(),
-        }
+        MissingDependencies { name: name.to_string(), version: version.to_string() }
     }
 }
 
@@ -34,10 +31,7 @@ pub struct UnzippingError {
 
 impl UnzippingError {
     pub fn new(name: &str, version: &str) -> UnzippingError {
-        UnzippingError {
-            name: name.to_string(),
-            version: version.to_string(),
-        }
+        UnzippingError { name: name.to_string(), version: version.to_string() }
     }
 }
 
@@ -49,10 +43,7 @@ pub struct IncorrectDependency {
 
 impl IncorrectDependency {
     pub fn new(name: &str, version: &str) -> IncorrectDependency {
-        IncorrectDependency {
-            name: name.to_string(),
-            version: version.to_string(),
-        }
+        IncorrectDependency { name: name.to_string(), version: version.to_string() }
     }
 }
 
@@ -98,10 +89,7 @@ pub struct ProjectNotFound {
 
 impl ProjectNotFound {
     pub fn new(name: &str, cause: &str) -> ProjectNotFound {
-        ProjectNotFound {
-            name: name.to_string(),
-            cause: cause.to_string(),
-        }
+        ProjectNotFound { name: name.to_string(), cause: cause.to_string() }
     }
 }
 
@@ -114,11 +102,7 @@ pub struct PushError {
 
 impl PushError {
     pub fn new(name: &str, version: &str, cause: &str) -> PushError {
-        PushError {
-            name: name.to_string(),
-            version: version.to_string(),
-            cause: cause.to_string(),
-        }
+        PushError { name: name.to_string(), version: version.to_string(), cause: cause.to_string() }
     }
 }
 
@@ -129,9 +113,7 @@ pub struct LoginError {
 
 impl LoginError {
     pub fn new(cause: &str) -> LoginError {
-        LoginError {
-            cause: cause.to_string(),
-        }
+        LoginError { cause: cause.to_string() }
     }
 }
 #[derive(Debug, Clone, PartialEq)]
@@ -141,8 +123,6 @@ pub struct ConfigError {
 
 impl ConfigError {
     pub fn new(cause: &str) -> ConfigError {
-        ConfigError {
-            cause: cause.to_string(),
-        }
+        ConfigError { cause: cause.to_string() }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,7 +453,10 @@ async fn update() -> Result<(), SoldeerError> {
 
 #[cfg(test)]
 mod tests {
-
+    use super::*;
+    use commands::{Init, Install, Push, Update};
+    use rand::{distributions::Alphanumeric, Rng};
+    use serial_test::serial;
     use std::{
         env::{self},
         fs::{
@@ -462,13 +465,7 @@ mod tests {
         io::Write,
         path::{Path, PathBuf},
     };
-
-    use commands::{Init, Install, Push, Update};
-    use rand::{distributions::Alphanumeric, Rng};
-    use serial_test::serial;
     use zip::ZipArchive; // 0.8
-
-    use super::*;
 
     #[test]
     #[serial]

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,17 +1,15 @@
-use crate::config::Dependency;
-use crate::errors::LockError;
-use crate::utils::{
-    get_current_working_dir,
-    read_file_to_string,
+use crate::{
+    config::Dependency,
+    errors::LockError,
+    utils::{get_current_working_dir, read_file_to_string},
+    LOCK_FILE,
 };
-use crate::LOCK_FILE;
 use serde_derive::Deserialize;
-use std::fs::{
-    self,
-    remove_file,
+use std::{
+    fs::{self, remove_file},
+    io::Write,
+    path::PathBuf,
 };
-use std::io::Write;
-use std::path::PathBuf;
 use yansi::Paint;
 
 // Top level struct to hold the TOML data.
@@ -47,9 +45,7 @@ fn read_lock() -> Result<Vec<LockEntry>, LockError> {
     };
 
     if !lock_file.exists() {
-        return Err(LockError {
-            cause: "Lock does not exists".to_string(),
-        });
+        return Err(LockError { cause: "Lock does not exists".to_string() });
     }
     let lock_path: String = lock_file.to_str().unwrap().to_string();
 
@@ -73,16 +69,11 @@ pub fn lock_check(
         Ok(entries) => entries,
         Err(_) => {
             if create_lock {
-                let _ = write_lock(&[], false).map_err(|_| {
-                    LockError {
-                        cause: "Could not write lock file".to_string(),
-                    }
-                });
+                let _ = write_lock(&[], false)
+                    .map_err(|_| LockError { cause: "Could not write lock file".to_string() });
                 vec![]
             } else {
-                return Err(LockError {
-                    cause: "Lock does not exists".to_string(),
-                });
+                return Err(LockError { cause: "Lock does not exists".to_string() });
             }
         }
     };
@@ -118,11 +109,7 @@ pub fn write_lock(dependencies: &[Dependency], clean: bool) -> Result<(), LockEr
     if clean && (lock_file).exists() {
         match remove_file(&lock_file) {
             Ok(_) => {}
-            Err(_) => {
-                return Err(LockError {
-                    cause: "Could not clean lock file".to_string(),
-                })
-            }
+            Err(_) => return Err(LockError { cause: "Could not clean lock file".to_string() }),
         }
     }
 
@@ -153,9 +140,7 @@ checksum = "{}"
     });
     let mut file: std::fs::File = fs::OpenOptions::new().append(true).open(lock_file).unwrap();
     if write!(file, "{}", new_lock_entries).is_err() {
-        return Err(LockError {
-            cause: "Could not write to the lock file".to_string(),
-        });
+        return Err(LockError { cause: "Could not write to the lock file".to_string() });
     }
     Ok(())
 }
@@ -186,15 +171,10 @@ checksum = "{}"
             ));
         }
     });
-    let mut file: std::fs::File = fs::OpenOptions::new()
-        .truncate(true)
-        .write(true)
-        .open(lock_file)
-        .unwrap();
+    let mut file: std::fs::File =
+        fs::OpenOptions::new().truncate(true).write(true).open(lock_file).unwrap();
     if write!(file, "{}", new_lock_entries).is_err() {
-        return Err(LockError {
-            cause: "Could not write to the lock file".to_string(),
-        });
+        return Err(LockError { cause: "Could not write to the lock file".to_string() });
     }
     Ok(())
 }
@@ -202,11 +182,9 @@ checksum = "{}"
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Dependency;
-    use crate::utils::read_file_to_string;
+    use crate::{config::Dependency, utils::read_file_to_string};
     use serial_test::serial;
-    use std::fs::File;
-    use std::io::Write;
+    use std::{fs::File, io::Write};
 
     fn check_lock_file() -> PathBuf {
         let lock_file: PathBuf = get_current_working_dir().join("test").join("soldeer.lock");
@@ -231,10 +209,7 @@ version = "0.6.5"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@prb-test~0.6.5.zip"
 checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#;
-        File::create(lock_file)
-            .unwrap()
-            .write_all(lock_contents.as_bytes())
-            .unwrap();
+        File::create(lock_file).unwrap().write_all(lock_contents.as_bytes()).unwrap();
     }
 
     #[test]

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -320,4 +320,101 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             e.cause == "Dependency @openzeppelin-contracts-2-2.6.0 is already installed"
         }));
     }
+
+    #[test]
+    #[serial]
+    fn remove_lock_single_success() {
+        let lock_file = check_lock_file();
+        let dependency = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.5.0".to_string(),
+            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip".to_string(),
+            hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
+        };
+        let dependencies = vec![dependency.clone()];
+        write_lock(&dependencies, false).unwrap();
+
+        match remove_lock(&dependency.name, &dependency.version) {
+            Ok(_) => {}
+            Err(_) => {
+                assert_eq!("Invalid State", "");
+            }
+        }
+        let contents = read_file_to_string(&lock_file.to_str().unwrap().to_string());
+
+        assert_eq!(contents, "".to_string());
+    }
+
+    #[test]
+    #[serial]
+    fn remove_lock_multiple_success() {
+        let lock_file = check_lock_file();
+        let dependency = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.5.0".to_string(),
+            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip".to_string(),
+            hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
+        };
+        let dependency2= Dependency {
+            name: "@openzeppelin-contracts2".to_string(),
+            version: "2.5.0".to_string(),
+            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip".to_string(),
+            hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
+        };
+        let dependencies = vec![dependency.clone(), dependency2.clone()];
+        write_lock(&dependencies, false).unwrap();
+
+        match remove_lock(&dependency.name, &dependency.version) {
+            Ok(_) => {}
+            Err(_) => {
+                assert_eq!("Invalid State", "");
+            }
+        }
+        let contents = read_file_to_string(&lock_file.to_str().unwrap().to_string());
+
+        assert_eq!(
+            contents,
+            r#"
+[[dependencies]]
+name = "@openzeppelin-contracts2"
+version = "2.5.0"
+source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
+checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+"#
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn remove_lock_one_fails() {
+        let lock_file = check_lock_file();
+        let dependency = Dependency {
+            name: "@openzeppelin-contracts".to_string(),
+            version: "2.5.0".to_string(),
+            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip".to_string(),
+            hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
+        };
+
+        let dependencies = vec![dependency.clone()];
+        write_lock(&dependencies, false).unwrap();
+
+        match remove_lock("non-existent", &dependency.version) {
+            Ok(_) => {}
+            Err(_) => {
+                assert_eq!("Invalid State", "");
+            }
+        }
+        let contents = read_file_to_string(&lock_file.to_str().unwrap().to_string());
+
+        assert_eq!(
+            contents,
+            r#"
+[[dependencies]]
+name = "@openzeppelin-contracts"
+version = "2.5.0"
+source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
+checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+"#
+        );
+    }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,13 +1,10 @@
-use crate::errors::DownloadError;
-use crate::errors::ProjectNotFound;
-use crate::utils::get_base_url;
-use chrono::DateTime;
-use chrono::Utc;
-use reqwest::Client;
-use serde_derive::{
-    Deserialize,
-    Serialize,
+use crate::{
+    errors::{DownloadError, ProjectNotFound},
+    utils::get_base_url,
 };
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde_derive::{Deserialize, Serialize};
 
 pub async fn get_dependency_url_remote(
     dependency_name: &String,
@@ -45,11 +42,7 @@ pub async fn get_dependency_url_remote(
 }
 //TODO clean this up and do error handling
 pub async fn get_project_id(dependency_name: &String) -> Result<String, ProjectNotFound> {
-    let url = format!(
-        "{}/api/v1/project?project_name={}",
-        get_base_url(),
-        dependency_name
-    );
+    let url = format!("{}/api/v1/project?project_name={}", get_base_url(), dependency_name);
     let req = Client::new().get(url);
     let get_project_response = req.send().await;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,21 +1,12 @@
 use regex::Regex;
 use simple_home_dir::home_dir;
-use std::env;
-use std::fs::{
-    self,
-    File,
+use std::{
+    env,
+    fs::{self, File},
+    io::{BufRead, BufReader, Read, Write},
+    path::{Path, PathBuf},
+    process::exit,
 };
-use std::io::Write;
-use std::io::{
-    BufRead,
-    BufReader,
-    Read,
-};
-use std::path::{
-    Path,
-    PathBuf,
-};
-use std::process::exit;
 use yansi::Paint;
 
 // get the current working directory
@@ -185,8 +176,8 @@ pub fn get_download_tunnel(dependency_url: &str) -> String {
     let pattern2 = r"^(https://github\.com|https://gitlab\.com)";
     let re1 = Regex::new(pattern1).unwrap();
     let re2 = Regex::new(pattern2).unwrap();
-    if re1.is_match(dependency_url)
-        || (re2.is_match(dependency_url) && dependency_url.ends_with(".git"))
+    if re1.is_match(dependency_url) ||
+        (re2.is_match(dependency_url) && dependency_url.ends_with(".git"))
     {
         return "git".to_string();
     }

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -312,13 +312,11 @@ async fn push_to_repo(
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{self, create_dir_all, remove_dir_all, remove_file};
-
-    use io::Cursor;
-    use serial_test::serial;
-
     use super::*;
+    use io::Cursor;
     use rand::{distributions::Alphanumeric, Rng};
+    use serial_test::serial;
+    use std::fs::{self, create_dir_all, remove_dir_all, remove_file};
 
     #[test]
     #[serial]

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -1,30 +1,17 @@
-use std::io;
-use std::{
-    env,
-    fs::{
-        self,
-        create_dir_all,
-        remove_dir_all,
-        remove_file,
-    },
-    path::{
-        Path,
-        PathBuf,
-    },
-    process::Command,
-};
-
 use serial_test::serial;
 use soldeer::{
-    commands::{
-        Install,
-        Subcommands,
-    },
+    commands::{Install, Subcommands},
     errors::SoldeerError,
-    DEPENDENCY_DIR,
-    LOCK_FILE,
+    DEPENDENCY_DIR, LOCK_FILE,
 };
-use std::io::Write;
+use std::{
+    env,
+    fs::{self, create_dir_all, remove_dir_all, remove_file},
+    io,
+    io::Write,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 extern crate soldeer;
 
@@ -102,10 +89,7 @@ contract TestSoldeer is Test {
     let _ = create_dir_all(test_project.join("dependencies").join("forge-std-1.8.2"));
 
     let _ = copy_dir_all(
-        env::current_dir()
-            .unwrap()
-            .join("dependencies")
-            .join("forge-std-1.8.2"),
+        env::current_dir().unwrap().join("dependencies").join("forge-std-1.8.2"),
         test_project.join("dependencies").join("forge-std-1.8.2"),
     );
 
@@ -128,10 +112,7 @@ contract TestSoldeer is Test {
 
     let passed = String::from_utf8(output.stdout).unwrap().contains("[PASS]");
     if !passed {
-        println!(
-            "This will fail with: {:?}",
-            String::from_utf8(output.stderr).unwrap()
-        );
+        println!("This will fail with: {:?}", String::from_utf8(output.stderr).unwrap());
     }
     assert!(passed);
     clean_test_env(&test_project);


### PR DESCRIPTION
The [rustfmt config from foundry](https://github.com/foundry-rs/foundry/blob/master/rustfmt.toml) has been borrowed, and files have been modified to match the styling of foundry in general.

The important points are:
- Imports are always present in a single group (no empty lines) and sorted alphabetically
- Imports from the same crate are joined into a single use statement
- Mod definitions come after the use statements

It's important to note that some of these formatter options are only available on nightly. Hence the command to use is `cargo +nightly fmt` or set the configuration of `rust-analyzer` to have the `rustfmt.extraArgs` option set to `["+nightly"]`.