### PR TITLE
Remappings refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/*
 !emptyfile2
 test_push_sensitive
 test_push_skip_sensitive
+test_project

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,4 @@
+
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
 [profile.default]
@@ -5,19 +6,7 @@ script = "script"
 solc = "0.8.26"
 src = "src"
 test = "test"
-
-libs = ["dependencies", "libs"]
-remappings = [
-    "@forge-std-1.8.2/=dependencies/@forge-std-1.8.2/",
-    "@openzeppelin-contracts-5.0.2/=dependencies/@openzeppelin-contracts-5.0.2/",
-]
-
+libs = ["dependencies"]
 
 [dependencies]
 forge-std = "1.8.2"
-"@openzeppelin-contracts" = "5.0.2"
-
-[soldeer]
-reg-remappings = false
-generate-remappings = true
-remappings-type = "config"

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,3 @@
-
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
 [profile.default]
@@ -6,8 +5,19 @@ script = "script"
 solc = "0.8.26"
 src = "src"
 test = "test"
-libs = ["dependencies","libs"]
+
+libs = ["dependencies", "libs"]
+remappings = [
+    "@forge-std-1.8.2/=dependencies/@forge-std-1.8.2/",
+    "@openzeppelin-contracts-5.0.2/=dependencies/@openzeppelin-contracts-5.0.2/",
+]
+
 
 [dependencies]
-forge-std = "1.9.1"
+forge-std = "1.8.2"
+"@openzeppelin-contracts" = "5.0.2"
 
+[soldeer]
+reg-remappings = false
+generate-remappings = true
+remappings-type = "config"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -34,24 +34,51 @@ pub struct Init {
 
 #[derive(Debug, Clone, Parser)]
 #[clap(
-    about = "Install a dependency from Soldeer repository or from a custom url that points to a zip file or from git using a git link.
-    IMPORTANT!! The `~` when specifying the dependency is very important to differentiate between the name and the version that needs to be installed.
-    Example from remote repository: soldeer install @openzeppelin-contracts~2.3.0
-    Example custom url: soldeer install @openzeppelin-contracts~2.3.0 https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v5.0.2.zip
-    Example git: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git
-    Example git with specified commit: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73
-    If you the remappings to be generated from scratch, use --reg-remappings true\n",
+    about = "Installing a Dependency
+
+You can install a dependency from the Soldeer repository, a custom URL pointing to a zip file, or from Git using a Git link.
+
+**Important:** The `~` symbol when specifying the dependency is crucial to differentiate between the name and the version that needs to be installed.
+
+- **Example from Soldeer repository:** 
+  soldeer install @openzeppelin-contracts~2.3.0
+
+- **Example from a custom URL:** 
+  soldeer install @openzeppelin-contracts~2.3.0 https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v5.0.2.zip
+
+- **Example from Git:** 
+  soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git
+
+- **Example from Git with a specified commit:** 
+  soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73
+
+If you want to regenerate the remappings from scratch, use
+  --reg-remappings true
+",
     after_help = "For more information, read the README.md",
     override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
 )]
 pub struct Install {
     #[clap(required = false)]
+    #[clap(
+        help = "Use this as [NAME]~[VERSION]. This should be always used if you want to install a certain dependency from: remote/custom url/git"
+    )]
     pub dependency: Option<String>,
     #[clap(required = false)]
+    #[arg(long, value_parser = clap::value_parser!(String))]
+    #[clap(
+        help = "Use this if your dependency is stored at a specific link in a zip file, e.g., https://my-domain/dep.zip."
+    )]
     pub remote_url: Option<String>,
     #[arg(long, value_parser = clap::value_parser!(String))]
+    #[clap(
+        help = "Set this to true if you want to specify a certain commit when installing a dependency from a Git repository."
+    )]
     pub rev: Option<String>,
     #[arg(long, value_parser = clap::value_parser!(bool))]
+    #[clap(
+        help = "Use this option set to true if you want to regenerate the remappings from scratch. This will delete the old remappings."
+    )]
     pub reg_remappings: Option<bool>,
 }
 
@@ -65,6 +92,9 @@ pub struct Update {
     #[arg(long, value_parser = clap::value_parser!(bool))]
     /// This regenerates the remappings from scratch, will delete old remappings and regenerate
     /// them
+    #[clap(
+        help = "Use this option set to true if you want to regenerate the remappings from scratch. This will delete the old remappings."
+    )]
     pub reg_remappings: Option<bool>,
 }
 
@@ -73,7 +103,7 @@ pub struct VersionDryRun {}
 
 #[derive(Debug, Clone, Parser)]
 #[clap(
-    about = "Login into the central repository to push the dependencies.",
+    about = "Log in to the central repository to push the dependencies.",
     after_help = "For more information, read the README.md",
     override_usage = "soldeer login"
 )]
@@ -81,17 +111,39 @@ pub struct Login {}
 
 #[derive(Debug, Clone, Parser)]
 #[clap(
-    about = "Push a dependency to the repository. The PATH_TO_DEPENDENCY is optional and if not provided, the current directory will be used.\nExample: If the directory is /home/soldeer/my_project and you do not specify the PATH_TO_DEPENDENCY,\nthe files inside the /home/soldeer/my_project will be pushed to the repository.\nIf you specify the PATH_TO_DEPENDENCY, the files inside the specified directory will be pushed to the repository.\nIf you want to ignore certain files, you can create a .soldeerignore file in the root of the project and add the files you want to ignore.\nThe .soldeerignore works like .gitignore.\nFor dry-run please use the --dry-run argument set to true, `soldeer push ... --dry-run true`. This will create a zip file that you can inspect and see what it will be pushed to the central repository.",
+    about = "Push a Dependency to the Repository
+The `PATH_TO_DEPENDENCY` is optional. If not provided, the current directory will be used.
+
+**Example:** 
+- If the current directory is `/home/soldeer/my_project` and you do not specify the `PATH_TO_DEPENDENCY`, the files inside `/home/soldeer/my_project` will be pushed to the repository.
+- If you specify the `PATH_TO_DEPENDENCY`, the files inside the specified directory will be pushed to the repository.
+
+To ignore certain files, create a `.soldeerignore` file in the root of the project and add the files you want to ignore. The `.soldeerignore` works like a `.gitignore`.
+
+For a dry run, use the `--dry-run` argument set to `true`: `soldeer push ... --dry-run true`. This will create a zip file that you can inspect to see what will be pushed to the central repository.",
     after_help = "For more information, read the README.md",
     override_usage = "soldeer push <DEPENDENCY>~<VERSION> [PATH_TO_DEPENDENCY]"
 )]
 pub struct Push {
     #[clap(required = true)]
+    #[clap(
+        help = "Use this format: `[NAME]~[VERSION]`. This should always be used when you want to push a dependency to the central repository: https://soldeer.xyz."
+    )]
     pub dependency: String,
+
+    #[clap(
+        help = "Use this if the dependency you want to push is not in the current directory. For example: `soldeer push /path/to/dep`."
+    )]
     pub path: Option<PathBuf>,
+    #[clap(
+        help = "Use this if you want to run a dry run. This will generate a zip file that you can inspect to see what will be pushed."
+    )]
     #[arg(short, long)]
     pub dry_run: Option<bool>,
     #[arg(long, value_parser = clap::value_parser!(bool))]
+    #[clap(
+        help = "Use this if you want to skip the warnings that can be triggered when trying to push .dot files like .env."
+    )]
     pub skip_warnings: Option<bool>,
 }
 
@@ -103,5 +155,8 @@ pub struct Push {
 )]
 pub struct Uninstall {
     #[clap(required = true)]
+    #[clap(
+        help = "Use this command as `soldeer uninstall [NAME]`. Specifying a version is unnecessary because there can only be one dependency with a given name"
+    )]
     pub dependency: String,
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -39,7 +39,8 @@ pub struct Init {
     Example from remote repository: soldeer install @openzeppelin-contracts~2.3.0
     Example custom url: soldeer install @openzeppelin-contracts~2.3.0 https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v5.0.2.zip
     Example git: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git
-    Example git with specified commit: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73\n",
+    Example git with specified commit: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73
+    If you the remappings to be generated from scratch, use --reg-remappings true\n",
     after_help = "For more information, read the README.md",
     override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
 )]
@@ -62,6 +63,8 @@ pub struct Install {
 )]
 pub struct Update {
     #[arg(long, value_parser = clap::value_parser!(bool))]
+    /// This regenerates the remappings from scratch, will delete old remappings and regenerate
+    /// them
     pub reg_remappings: Option<bool>,
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -52,6 +52,8 @@ pub struct Install {
     pub remote_url: Option<String>,
     #[arg(long, value_parser = clap::value_parser!(String))]
     pub rev: Option<String>,
+    #[arg(long, value_parser = clap::value_parser!(bool))]
+    pub reg_remappings: Option<bool>,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -60,7 +62,10 @@ pub struct Install {
     after_help = "For more information, read the README.md",
     override_usage = "soldeer update"
 )]
-pub struct Update {}
+pub struct Update {
+    #[arg(long, value_parser = clap::value_parser!(bool))]
+    pub reg_remappings: Option<bool>,
+}
 
 #[derive(Debug, Clone, Parser)]
 pub struct VersionDryRun {}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -59,7 +59,7 @@ If you want to regenerate the remappings from scratch, use
     override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
 )]
 pub struct Install {
-    /// Use this as [NAME]~[VERSION]. This should be always used if you want to install a certain
+    /// Use this as `[NAME]~[VERSION]`. This should be always used if you want to install a certain
     /// dependency from: remote/custom url/git
     #[clap(required = false)]
     pub dependency: Option<String>,
@@ -119,7 +119,7 @@ For a dry run, use the `--dry-run` argument set to `true`: `soldeer push ... --d
     override_usage = "soldeer push <DEPENDENCY>~<VERSION> [PATH_TO_DEPENDENCY]"
 )]
 pub struct Push {
-    /// Use this format: `[NAME]~[VERSION]`. This should always be used when you want to push a dependency to the central repository: https://soldeer.xyz.
+    /// Use this format: `[NAME]~[VERSION]`. This should always be used when you want to push a dependency to the central repository: `<https://soldeer.xyz>`.
     #[clap(required = true)]
     pub dependency: String,
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -28,7 +28,7 @@ Use --clean true if you want to delete .gitmodules and lib directory that were c
     override_usage = "soldeer init"
 )]
 pub struct Init {
-    #[arg(long, value_parser = clap::value_parser!(bool))]
+    #[arg(long)]
     pub clean: Option<bool>,
 }
 
@@ -59,26 +59,23 @@ If you want to regenerate the remappings from scratch, use
     override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
 )]
 pub struct Install {
+    /// Use this as [NAME]~[VERSION]. This should be always used if you want to install a certain
+    /// dependency from: remote/custom url/git
     #[clap(required = false)]
-    #[clap(
-        help = "Use this as [NAME]~[VERSION]. This should be always used if you want to install a certain dependency from: remote/custom url/git"
-    )]
     pub dependency: Option<String>,
+
+    /// Use this if your dependency is stored at a specific link in a zip file, e.g., https://my-domain/dep.zip.
     #[clap(required = false)]
-    #[arg(long, value_parser = clap::value_parser!(String))]
-    #[clap(
-        help = "Use this if your dependency is stored at a specific link in a zip file, e.g., https://my-domain/dep.zip."
-    )]
     pub remote_url: Option<String>,
-    #[arg(long, value_parser = clap::value_parser!(String))]
-    #[clap(
-        help = "Set this to true if you want to specify a certain commit when installing a dependency from a Git repository."
-    )]
+
+    /// Set this to true if you want to specify a certain commit when installing a dependency from
+    /// a Git repository.
+    #[arg(long)]
     pub rev: Option<String>,
-    #[arg(long, value_parser = clap::value_parser!(bool))]
-    #[clap(
-        help = "Use this option set to true if you want to regenerate the remappings from scratch. This will delete the old remappings."
-    )]
+
+    /// Use this option set to true if you want to regenerate the remappings from scratch. This
+    /// will delete the old remappings.
+    #[arg(long)]
     pub reg_remappings: Option<bool>,
 }
 
@@ -89,12 +86,9 @@ pub struct Install {
     override_usage = "soldeer update"
 )]
 pub struct Update {
-    #[arg(long, value_parser = clap::value_parser!(bool))]
-    /// This regenerates the remappings from scratch, will delete old remappings and regenerate
-    /// them
-    #[clap(
-        help = "Use this option set to true if you want to regenerate the remappings from scratch. This will delete the old remappings."
-    )]
+    /// Use this option set to true if you want to regenerate the remappings from scratch. This
+    /// will delete the old remappings.
+    #[arg(long)]
     pub reg_remappings: Option<bool>,
 }
 
@@ -125,25 +119,22 @@ For a dry run, use the `--dry-run` argument set to `true`: `soldeer push ... --d
     override_usage = "soldeer push <DEPENDENCY>~<VERSION> [PATH_TO_DEPENDENCY]"
 )]
 pub struct Push {
+    /// Use this format: `[NAME]~[VERSION]`. This should always be used when you want to push a dependency to the central repository: https://soldeer.xyz.
     #[clap(required = true)]
-    #[clap(
-        help = "Use this format: `[NAME]~[VERSION]`. This should always be used when you want to push a dependency to the central repository: https://soldeer.xyz."
-    )]
     pub dependency: String,
 
-    #[clap(
-        help = "Use this if the dependency you want to push is not in the current directory. For example: `soldeer push /path/to/dep`."
-    )]
+    /// Use this if the dependency you want to push is not in the current directory. For example:
+    /// `soldeer push /path/to/dep`.
     pub path: Option<PathBuf>,
-    #[clap(
-        help = "Use this if you want to run a dry run. This will generate a zip file that you can inspect to see what will be pushed."
-    )]
+
+    /// Use this if you want to run a dry run. This will generate a zip file that you can inspect
+    /// to see what will be pushed.
     #[arg(short, long)]
     pub dry_run: Option<bool>,
-    #[arg(long, value_parser = clap::value_parser!(bool))]
-    #[clap(
-        help = "Use this if you want to skip the warnings that can be triggered when trying to push .dot files like .env."
-    )]
+
+    /// Use this if you want to skip the warnings that can be triggered when trying to push .dot
+    /// files like .env.
+    #[arg(long)]
     pub skip_warnings: Option<bool>,
 }
 
@@ -154,9 +145,8 @@ pub struct Push {
     override_usage = "soldeer uninstall <DEPENDENCY>"
 )]
 pub struct Uninstall {
+    /// Use this command as `soldeer uninstall [NAME]`. Specifying a version is unnecessary because
+    /// there can only be one dependency with a given name
     #[clap(required = true)]
-    #[clap(
-        help = "Use this command as `soldeer uninstall [NAME]`. Specifying a version is unnecessary because there can only be one dependency with a given name"
-    )]
     pub dependency: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ async fn install_dependency(
 
     if soldeer_config.generate_remappings {
         if soldeer_config.remappings_type == "config" {
-            match remappings_foundry(&dependency, &config_file, soldeer_config).await {
+            match remappings_foundry(dependency, &config_file, soldeer_config).await {
                 Ok(_) => {}
                 Err(err) => {
                     return Err(SoldeerError { message: err.cause });
@@ -509,6 +509,7 @@ mod tests {
         io::Write,
         path::{Path, PathBuf},
     };
+    use utils::read_file_to_string;
     use zip::ZipArchive; // 0.8
 
     #[test]
@@ -547,7 +548,7 @@ libs = ["dependencies"]
         match run(command) {
             Ok(_) => {}
             Err(_) => {
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
@@ -557,7 +558,7 @@ libs = ["dependencies"]
         assert!(path_dependency.exists());
         path_dependency = DEPENDENCY_DIR.join("@openzeppelin-contracts-5.0.2");
         assert!(path_dependency.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -595,7 +596,7 @@ libs = ["dependencies"]
         match run(command) {
             Ok(_) => {}
             Err(_) => {
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
@@ -603,7 +604,7 @@ libs = ["dependencies"]
         let path_dependency = DEPENDENCY_DIR.join("@tt-1.6.1");
 
         assert!(path_dependency.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -636,7 +637,7 @@ libs = ["dependencies"]
         match run(command) {
             Ok(_) => {}
             Err(_) => {
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
@@ -644,7 +645,7 @@ libs = ["dependencies"]
         let path_dependency = DEPENDENCY_DIR.join("@tt-1.6.1");
 
         assert!(path_dependency.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -680,7 +681,7 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 println!("Err {:?}", err);
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
@@ -698,7 +699,7 @@ libs = ["dependencies"]
         let path_dependency = DEPENDENCY_DIR.join("@dep3-3.3").join("JustATest2.md");
         assert!(path_dependency.exists());
 
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -739,7 +740,7 @@ libs = ["dependencies"]
         match run(command) {
             Ok(_) => {}
             Err(err) => {
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 // can not generalize as diff systems return various dns errors
                 assert!(err.message.contains("Error downloading a dependency will-fail~1"))
             }
@@ -750,7 +751,7 @@ libs = ["dependencies"]
         assert!(!path_dependency.exists());
         path_dependency = DEPENDENCY_DIR.join("@openzeppelin-contracts-5.0.2");
         assert!(!path_dependency.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -778,7 +779,7 @@ libs = ["dependencies"]
         match run(command) {
             Ok(_) => {}
             Err(_) => {
-                clean_test_env(PathBuf::default());
+                clean_test_env(&PathBuf::default());
                 assert_eq!("Invalid State", "")
             }
         }
@@ -816,7 +817,7 @@ libs = ["dependencies"]
         match run(command) {
             Ok(_) => {}
             Err(_) => {
-                clean_test_env(PathBuf::default());
+                clean_test_env(&PathBuf::default());
                 assert_eq!("Invalid State", "")
             }
         }
@@ -858,7 +859,7 @@ libs = ["dependencies"]
                 println!("Push command succeeded as expected");
             }
             Err(e) => {
-                clean_test_env(PathBuf::default());
+                clean_test_env(&PathBuf::default());
 
                 // Check if the error is due to not being logged in
                 if e.message.contains("You are not logged in") {
@@ -926,14 +927,14 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 println!("Err {}", err);
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
 
         let path_dependency = DEPENDENCY_DIR.join("forge-std-1.9.1").join("src").join("Test.sol");
         assert!(path_dependency.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -978,14 +979,14 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 println!("Err {}", err);
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
 
         let path_dependency = DEPENDENCY_DIR.join("forge-std-1.9.1").join("src").join("Test.sol");
         assert!(path_dependency.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -1030,14 +1031,14 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 println!("Err {}", err);
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
 
         let path_dependency = DEPENDENCY_DIR.join("forge-std-1.9.1").join("src").join("Test.sol");
         assert!(path_dependency.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -1082,14 +1083,14 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 println!("Err {}", err);
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
 
         let path_dependency = DEPENDENCY_DIR.join("forge-std-1.9.1").join("src").join("Test.sol");
         assert!(path_dependency.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -1134,7 +1135,7 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 println!("Err {}", err);
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
@@ -1144,7 +1145,7 @@ libs = ["dependencies"]
         assert!(!path_dependency.exists()); // this should not exists at that commit
         path_dependency = DEPENDENCY_DIR.join("forge-std-1.9.1").join("src").join("Test.sol");
         assert!(path_dependency.exists()); // this should exists at that commit
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -1165,7 +1166,7 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 println!("{:?}", err);
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
@@ -1174,7 +1175,7 @@ libs = ["dependencies"]
         let lock_test = get_current_working_dir().join("test").join("soldeer.lock");
         assert!(path_dependency.exists());
         assert!(lock_test.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
     }
 
     #[test]
@@ -1214,7 +1215,7 @@ libs = ["dependencies"]
             Ok(_) => {}
             Err(err) => {
                 println!("{:?}", err);
-                clean_test_env(target_config.clone());
+                clean_test_env(&target_config);
                 assert_eq!("Invalid State", "")
             }
         }
@@ -1223,16 +1224,502 @@ libs = ["dependencies"]
         assert!(lock_test.exists());
         assert!(!submodules_path.exists());
         assert!(!lib_path.exists());
-        clean_test_env(target_config);
+        clean_test_env(&target_config);
         let _ = remove_file(submodules_path);
         let _ = remove_dir_all(lib_path);
     }
 
-    fn clean_test_env(target_config: PathBuf) {
+    #[test]
+    #[serial]
+    fn install_dependency_generate_remappings_in_config() {
         let _ = remove_dir_all(DEPENDENCY_DIR.clone());
         let _ = remove_file(LOCK_FILE.clone());
-        if target_config != PathBuf::default() {
-            let _ = remove_file(&target_config);
+        let test_dir = env::current_dir().unwrap().join("test").join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+
+[soldeer]
+generate-remappings = true
+remappings-type = "config"
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Option::None,
+            rev: None,
+            reg_remappings: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(&target_config);
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let expected_contents = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+remappings = ["@forge-std-1.9.1/=dependencies/@forge-std-1.9.1/"]
+
+[dependencies]
+forge-std = "1.9.1"
+
+[soldeer]
+generate-remappings = true
+remappings-type = "config"
+"#;
+        let contents = read_file_to_string(&target_config);
+        assert_eq!(contents, expected_contents);
+        clean_test_env(&target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_generate_remappings_in_config_multiple_profiles() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir().unwrap().join("test").join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[profile.test]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[profile.prod]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+
+[soldeer]
+generate-remappings = true
+remappings-type = "config"
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Option::None,
+            rev: None,
+            reg_remappings: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(&target_config);
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let expected_contents = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+remappings = ["@forge-std-1.9.1/=dependencies/@forge-std-1.9.1/"]
+
+[profile.test]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+remappings = ["@forge-std-1.9.1/=dependencies/@forge-std-1.9.1/"]
+
+[profile.prod]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+remappings = ["@forge-std-1.9.1/=dependencies/@forge-std-1.9.1/"]
+
+[dependencies]
+forge-std = "1.9.1"
+
+[soldeer]
+generate-remappings = true
+remappings-type = "config"
+"#;
+        let contents = read_file_to_string(&target_config);
+        assert_eq!(contents, expected_contents);
+        clean_test_env(&target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_generate_remappings_in_txt() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir().unwrap().join("test").join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+
+[soldeer]
+generate-remappings = true
+remappings-type = "txt"
+"#;
+
+        let target_config = define_config(true);
+        clean_test_env(&target_config);
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Option::None,
+            rev: None,
+            reg_remappings: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(&target_config);
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let expected_contents = "@forge-std-1.9.1=dependencies/forge-std-1.9.1".to_string();
+        let contents = read_file_to_string(get_current_working_dir().join("remappings.txt"));
+        assert_eq!(contents, expected_contents);
+        clean_test_env(&target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_generate_remappings_in_txt_even_if_the_remap_type_is_not_defined() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir().unwrap().join("test").join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+
+[soldeer]
+generate-remappings = true
+"#;
+
+        let target_config = define_config(true);
+        clean_test_env(&target_config);
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Option::None,
+            rev: None,
+            reg_remappings: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(&target_config);
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let expected_contents = "@forge-std-1.9.1=dependencies/forge-std-1.9.1".to_string();
+        let contents = read_file_to_string(get_current_working_dir().join("remappings.txt"));
+        assert_eq!(contents, expected_contents);
+        clean_test_env(&target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn install_dependency_does_not_generate_remappings() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir().unwrap().join("test").join("install_http");
+        let remappings_file = get_current_working_dir().join("remappings.txt");
+        let _ = remove_file(&remappings_file);
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+
+[soldeer]
+generate-remappings = false
+"#;
+
+        let target_config = define_config(true);
+        clean_test_env(&target_config);
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Install(Install {
+            dependency: Some("forge-std~1.9.1".to_string()),
+            remote_url: Option::None,
+            rev: None,
+            reg_remappings: None,
+        });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(&target_config);
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        assert!(!remappings_file.exists());
+        let contents = read_file_to_string(&target_config);
+        assert!(!contents.contains("remappings = ["));
+        clean_test_env(&target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn update_generate_remappings_in_config() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir().unwrap().join("test").join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+forge-std = "1.9.1"
+
+[soldeer]
+generate-remappings = true
+remappings-type = "config"
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Update(Update { reg_remappings: Some(true) });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(&target_config);
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let expected_contents = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+remappings = ["@forge-std-1.9.1/=dependencies/@forge-std-1.9.1/"]
+
+[dependencies]
+forge-std = "1.9.1"
+
+[soldeer]
+generate-remappings = true
+remappings-type = "config"
+"#;
+        let contents = read_file_to_string(&target_config);
+        assert_eq!(contents, expected_contents);
+        clean_test_env(&target_config);
+    }
+
+    #[test]
+    #[serial]
+    fn update_with_no_dep_does_not_generate_remappings_in_config() {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        let test_dir = env::current_dir().unwrap().join("test").join("install_http");
+
+        // Create test directory
+        if !test_dir.exists() {
+            std::fs::create_dir(&test_dir).unwrap();
+        }
+
+        let content = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+
+[soldeer]
+generate-remappings = true
+remappings-type = "config"
+"#;
+
+        let target_config = define_config(true);
+
+        write_to_config(&target_config, content);
+
+        env::set_var("base_url", "https://api.soldeer.xyz");
+
+        let command = Subcommands::Update(Update { reg_remappings: Some(true) });
+
+        match run(command) {
+            Ok(_) => {}
+            Err(err) => {
+                println!("Err {}", err);
+                clean_test_env(&target_config);
+                assert_eq!("Invalid State", "")
+            }
+        }
+
+        let expected_contents = r#"
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+
+[soldeer]
+generate-remappings = true
+remappings-type = "config"
+"#;
+        let contents = read_file_to_string(&target_config);
+        assert_eq!(contents, expected_contents);
+        clean_test_env(&target_config);
+    }
+
+    fn clean_test_env(target_config: &PathBuf) {
+        let _ = remove_dir_all(DEPENDENCY_DIR.clone());
+        let _ = remove_file(LOCK_FILE.clone());
+        if target_config.clone() != PathBuf::default() {
+            let _ = remove_file(target_config);
             let parent = target_config.parent();
             let lock = parent.unwrap().join("soldeer.lock");
             let _ = remove_file(lock);
@@ -1255,7 +1742,7 @@ libs = ["dependencies"]
             rand::thread_rng().sample_iter(&Alphanumeric).take(7).map(char::from).collect();
         let mut target = format!("foundry{}.toml", s);
         if !foundry {
-            target = format!("Soldeer{}.toml", s);
+            target = format!("soldeer{}.toml", s);
         }
 
         let path = env::current_dir().unwrap().join("test").join(target);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,10 @@
 use crate::{
     auth::login,
     commands::Subcommands,
-    config::{delete_config, get_foundry_setup, read_config, remappings, Dependency},
+    config::{
+        add_to_config, define_config_file, delete_config, read_config_deps, read_config_soldeer,
+        remappings_foundry, remappings_txt, Dependency,
+    },
     dependency_downloader::{
         delete_dependency_files, download_dependencies, unzip_dependencies, unzip_dependency,
     },
@@ -12,7 +15,6 @@ use crate::{
     utils::{check_dotfiles_recursive, get_current_working_dir, prompt_user_for_confirmation},
     versioning::push_version,
 };
-use config::{add_to_config, define_config_file};
 use dependency_downloader::download_dependency;
 use janitor::cleanup_dependency;
 use once_cell::sync::Lazy;
@@ -40,11 +42,6 @@ pub static SOLDEER_CONFIG_FILE: Lazy<PathBuf> =
     Lazy::new(|| get_current_working_dir().join("soldeer.toml"));
 pub static FOUNDRY_CONFIG_FILE: Lazy<PathBuf> =
     Lazy::new(|| get_current_working_dir().join("foundry.toml"));
-
-#[derive(Debug)]
-pub struct FOUNDRY {
-    remappings: bool,
-}
 
 #[tokio::main]
 pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
@@ -638,9 +635,7 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command = Subcommands::Update(Update {
-            reg_remappings: None,
-        });
+        let command = Subcommands::Update(Update { reg_remappings: None });
 
         match run(command) {
             Ok(_) => {}
@@ -683,9 +678,7 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command = Subcommands::Update(Update {
-            reg_remappings: None,
-        });
+        let command = Subcommands::Update(Update { reg_remappings: None });
 
         match run(command) {
             Ok(_) => {}

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -94,14 +94,27 @@ contract TestSoldeer is Test {
         test_project.join("dependencies").join("forge-std-1.8.2"),
     );
 
-    let _ = fs::copy(
-        env::current_dir().unwrap().join("foundry.toml"),
-        test_project.join("foundry.toml"),
-    );
+    let foundry_content = r#"
+    
+# Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
-    let _ = fs::copy(
-        env::current_dir().unwrap().join("remappings.txt"),
+[profile.default]
+script = "script"
+solc = "0.8.26"
+src = "src"
+test = "test"
+libs = ["dependencies"]
+
+[dependencies]
+forge-std = "1.8.2"
+
+"#;
+
+    let _ = fs::write(test_project.join("foundry.toml"), foundry_content);
+
+    let _ = fs::write(
         test_project.join("remappings.txt"),
+        "@forge-std-1.8.2=dependencies/forge-std-1.8.2",
     );
 
     let output = Command::new("forge")

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -37,6 +37,7 @@ fn soldeer_install_valid_dependency() {
         dependency: Some("forge-std~1.8.2".to_string()),
         remote_url: None,
         rev: None,
+        reg_remappings: None,
     });
 
     match soldeer::run(command) {
@@ -144,6 +145,7 @@ fn soldeer_install_invalid_dependency() {
         dependency: Some("forge-std".to_string()),
         remote_url: None,
         rev: None,
+        reg_remappings: None,
     });
 
     match soldeer::run(command) {

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -24,7 +24,7 @@ fn soldeer_install_valid_dependency() {
         dependency: Some("forge-std~1.8.2".to_string()),
         remote_url: None,
         rev: None,
-        reg_remappings: None,
+        reg_remappings: Some(false),
     });
 
     match soldeer::run(command) {
@@ -113,7 +113,7 @@ contract TestSoldeer is Test {
 
     let passed = String::from_utf8(output.stdout).unwrap().contains("[PASS]");
     if !passed {
-        println!("This will fail with: {:?}", String::from_utf8(output.stderr).unwrap());
+        eprintln!("This failed with: {:?}", String::from_utf8(output.stderr).unwrap());
     }
     assert!(passed);
     clean_test_env(&test_project);


### PR DESCRIPTION
 This introduces the following changes: the config file now contains a field that can be used to specify Soldeer-related settings. For example, you can specify where the remappings should be written, such as in the Foundry config or a  file, or indicate if you don't want to generate remappings at all.