### PR TITLE
refactor!: cleanup, more idiomatic rust

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -165,7 +165,7 @@ mod tests {
         .await
         {
             Ok(_) => {
-                let results = read_file_to_string(&"./test_save_jwt".to_string());
+                let results = read_file_to_string("./test_save_jwt");
                 assert_eq!(results, "jwt_token_example");
                 let _ = remove_file("./test_save_jwt");
             }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 /// A minimal solidity dependency manager.
 #[derive(Parser, Debug)]
@@ -33,9 +34,9 @@ pub struct Init {
 
 #[derive(Debug, Clone, Parser)]
 #[clap(
-    about = "Install a dependency from Soldeer repository or from a custom url that points to a zip file or from git using a git link. 
+    about = "Install a dependency from Soldeer repository or from a custom url that points to a zip file or from git using a git link.
     IMPORTANT!! The `~` when specifying the dependency is very important to differentiate between the name and the version that needs to be installed.
-    Example from remote repository: soldeer install @openzeppelin-contracts~2.3.0 
+    Example from remote repository: soldeer install @openzeppelin-contracts~2.3.0
     Example custom url: soldeer install @openzeppelin-contracts~2.3.0 https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v5.0.2.zip
     Example git: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git
     Example git with specified commit: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73\n",
@@ -79,7 +80,7 @@ pub struct Login {}
 pub struct Push {
     #[clap(required = true)]
     pub dependency: String,
-    pub path: Option<String>,
+    pub path: Option<PathBuf>,
     #[arg(short, long)]
     pub dry_run: Option<bool>,
     #[arg(long, value_parser = clap::value_parser!(bool))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,7 @@ pub async fn read_config(filename: String) -> Result<Vec<Dependency>, ConfigErro
             Err(err) => return Err(err),
         }
     }
-    let contents = read_file_to_string(&filename.clone());
+    let contents = read_file_to_string(&filename);
 
     // reading the contents into a data structure using toml::from_str
     let data: Data = match toml::from_str(&contents) {
@@ -153,7 +153,7 @@ pub fn add_to_config(
         ))
     );
 
-    let contents = read_file_to_string(&String::from(config_file));
+    let contents = read_file_to_string(config_file);
     let mut doc: DocumentMut = contents.parse::<DocumentMut>().expect("invalid doc");
 
     // in case we don't have dependencies defined in the config file, we add it and re-read the doc
@@ -164,9 +164,7 @@ pub fn add_to_config(
             eprintln!("Couldn't write to the config file: {}", e);
         }
 
-        doc = read_file_to_string(&String::from(config_file))
-            .parse::<DocumentMut>()
-            .expect("invalid doc");
+        doc = read_file_to_string(config_file).parse::<DocumentMut>().expect("invalid doc");
     }
     let mut new_dependencies: String = String::new();
 
@@ -204,7 +202,7 @@ pub async fn remappings() -> Result<(), ConfigError> {
     if !remappings_path.exists() {
         File::create(remappings_path.clone()).unwrap();
     }
-    let contents = read_file_to_string(&remappings_path.to_str().unwrap().to_string());
+    let contents = read_file_to_string(&remappings_path);
 
     let existing_remappings: Vec<String> = contents.split('\n').map(|s| s.to_string()).collect();
     let mut new_remappings: String = String::new();
@@ -275,7 +273,7 @@ pub fn get_foundry_setup() -> Result<Vec<bool>, ConfigError> {
     if filename.contains("foundry.toml") {
         return Ok(vec![true]);
     }
-    let contents: String = read_file_to_string(&filename.clone());
+    let contents: String = read_file_to_string(&filename);
 
     // reading the contents into a data structure using toml::from_str
     let data: Foundry = match toml::from_str(&contents) {
@@ -307,7 +305,7 @@ pub fn delete_config(
         Paint::green(&format!("Removing the dependency {} from the config file", dependency_name))
     );
 
-    let contents = read_file_to_string(&String::from(config_file));
+    let contents = read_file_to_string(config_file);
     let mut doc: DocumentMut = contents.parse::<DocumentMut>().expect("invalid doc");
 
     if !doc.contains_table("dependencies") {
@@ -770,7 +768,7 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, config_contents);
 
-        assert!(target_config.file_name().unwrap().to_str().unwrap().contains("foundry"));
+        assert!(target_config.file_name().unwrap().to_string_lossy().contains("foundry"));
         let _ = remove_file(target_config);
         Ok(())
     }
@@ -785,7 +783,7 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, config_contents);
 
-        assert!(target_config.file_name().unwrap().to_str().unwrap().contains("soldeer"));
+        assert!(target_config.file_name().unwrap().to_string_lossy().contains("soldeer"));
         let _ = remove_file(target_config);
         Ok(())
     }
@@ -807,7 +805,7 @@ libs = ["dependencies"]
 
         let result = create_example_config("1").unwrap();
 
-        assert!(PathBuf::from(&result).file_name().unwrap().to_str().unwrap().contains("foundry"));
+        assert!(PathBuf::from(&result).file_name().unwrap().to_string_lossy().contains("foundry"));
         assert_eq!(read_file_to_string(&result), content);
         Ok(())
     }
@@ -823,7 +821,7 @@ enabled = true
 
         let result = create_example_config("2").unwrap();
 
-        assert!(PathBuf::from(&result).file_name().unwrap().to_str().unwrap().contains("soldeer"));
+        assert!(PathBuf::from(&result).file_name().unwrap().to_string_lossy().contains("soldeer"));
         assert_eq!(read_file_to_string(&result), content);
         Ok(())
     }
@@ -867,7 +865,7 @@ libs = ["dependencies"]
 dep1 = "1.0.0"
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -914,7 +912,7 @@ libs = ["dependencies"]
 dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -963,7 +961,7 @@ old_dep = "5.1.0-my-version-is-cool"
 dep1 = "1.0.0"
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1012,7 +1010,7 @@ old_dep = { version = "5.1.0-my-version-is-cool", url = "http://custom_url.com/c
 dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1060,7 +1058,7 @@ libs = ["dependencies"]
 old_dep = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1108,7 +1106,7 @@ libs = ["dependencies"]
 old_dep = "1.0.0"
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1159,7 +1157,7 @@ gas_reports = ['*']
 dep1 = "1.0.0"
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1194,7 +1192,7 @@ enabled = true
 dep1 = "1.0.0"
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1229,7 +1227,7 @@ enabled = true
 dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1280,7 +1278,7 @@ gas_reports = ['*']
 dep1 = { version = "1.0.0", git = "git@github.com:foundry-rs/forge-std.git", rev = "07263d193d621c4b2b0ce8b4d54af58f6957d97d" }
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1335,7 +1333,7 @@ gas_reports = ['*']
 dep1 = { version = "1.0.0", git = "git@github.com:foundry-rs/forge-std.git", rev = "07263d193d621c4b2b0ce8b4d54af58f6957d97d" }
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1389,7 +1387,7 @@ gas_reports = ['*']
 dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1436,7 +1434,7 @@ libs = ["dependencies"]
 [dependencies]
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1487,7 +1485,7 @@ dep3 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 dep2 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 "#;
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())
@@ -1527,7 +1525,7 @@ dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
             }
         }
 
-        assert_eq!(read_file_to_string(&String::from(target_config.to_str().unwrap())), content);
+        assert_eq!(read_file_to_string(&target_config), content);
 
         let _ = remove_file(target_config);
         Ok(())

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -708,7 +708,7 @@ mod tests {
         });
         download_dependencies(&dependencies, false).await.unwrap();
         unzip_dependency(&dependencies[0].name, &dependencies[0].version).unwrap();
-        healthcheck_dependency("@openzeppelin-contracts", "3.3.0-custom-test").unwrap();
+        healthcheck_dependency(&dependencies[0]).unwrap();
         assert!(DEPENDENCY_DIR
             .join("@openzeppelin-contracts-3.3.0-custom-test")
             .join("token")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@ use crate::{
 };
 use config::{add_to_config, define_config_file};
 use dependency_downloader::download_dependency;
-use janitor::cleanup_dependency;
+use janitor::{cleanup_dependency, CleanupParams};
+use lock::LockWriteMode;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use remote::{get_dependency_url_remote, get_latest_forge_std_dependency};
@@ -157,15 +158,14 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             }
         }
         Subcommands::Push(push) => {
-            let path = push.path.unwrap_or(get_current_working_dir().to_str().unwrap().to_string());
-            let path_buf = PathBuf::from(&path);
+            let path = push.path.unwrap_or(get_current_working_dir());
             let dry_run = push.dry_run.is_some() && push.dry_run.unwrap();
             let skip_warnings = push.skip_warnings.unwrap_or(false);
 
             // Check for sensitive files or directories
             if !dry_run &&
                 !skip_warnings &&
-                check_dotfiles_recursive(&path_buf) &&
+                check_dotfiles_recursive(&path) &&
                 !prompt_user_for_confirmation()
             {
                 Paint::yellow("Push operation aborted by the user.");
@@ -197,9 +197,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             if !regex.is_match(&dependency_name) {
                 return Err(SoldeerError{message:format!("Dependency name {} is not valid, you can use only alphanumeric characters `-` and `@`", &dependency_name)});
             }
-            match push_version(&dependency_name, &dependency_version, PathBuf::from(&path), dry_run)
-                .await
-            {
+            match push_version(&dependency_name, &dependency_version, path, dry_run).await {
                 Ok(_) => {}
                 Err(err) => {
                     return Err(SoldeerError {
@@ -235,7 +233,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             let _ = delete_dependency_files(&dependency).is_ok();
 
             // removing the dependency from the lock file
-            match remove_lock(&dependency.name, &dependency.version) {
+            match remove_lock(&dependency) {
                 Ok(d) => d,
                 Err(err) => {
                     return Err(SoldeerError { message: err.cause });
@@ -275,7 +273,7 @@ async fn install_dependency(
         }
     };
 
-    match write_lock(&[dependency.clone()], false) {
+    match write_lock(&[dependency.clone()], LockWriteMode::Append) {
         Ok(_) => {}
         Err(err) => {
             return Err(SoldeerError { message: format!("Error writing the lock: {}", err.cause) });
@@ -287,10 +285,8 @@ async fn install_dependency(
             Ok(_) => {}
             Err(err_unzip) => {
                 match janitor::cleanup_dependency(
-                    &dependency.name,
-                    &dependency.version,
-                    true,
-                    false,
+                    dependency,
+                    CleanupParams { full: true, via_git: false },
                 ) {
                     Ok(_) => {}
                     Err(err_cleanup) => {
@@ -315,7 +311,7 @@ async fn install_dependency(
     let config_file: String = match define_config_file() {
         Ok(file) => file,
 
-        Err(_) => match cleanup_dependency(&dependency.name, &dependency.version, true, via_git) {
+        Err(_) => match cleanup_dependency(dependency, CleanupParams { full: true, via_git }) {
             Ok(_) => {
                 return Err(SoldeerError {
                     message: "Could not define the config file".to_string(),
@@ -336,7 +332,7 @@ async fn install_dependency(
         }
     }
 
-    match janitor::healthcheck_dependency(&dependency.name, &dependency.version) {
+    match janitor::healthcheck_dependency(dependency) {
         Ok(_) => {}
         Err(err) => {
             return Err(SoldeerError {
@@ -345,7 +341,7 @@ async fn install_dependency(
         }
     }
 
-    match janitor::cleanup_dependency(&dependency.name, &dependency.version, false, via_git) {
+    match janitor::cleanup_dependency(dependency, CleanupParams { full: false, via_git }) {
         Ok(_) => {}
         Err(err) => {
             return Err(SoldeerError {
@@ -414,7 +410,7 @@ async fn update() -> Result<(), SoldeerError> {
         }
     }
 
-    match write_lock(&dependencies, true) {
+    match write_lock(&dependencies, LockWriteMode::Replace) {
         Ok(_) => {}
         Err(err) => {
             return Err(SoldeerError { message: format!("Error writing the lock: {}", err.cause) });
@@ -714,7 +710,7 @@ libs = ["dependencies"]
 
         let command = Subcommands::Push(Push {
             dependency: "@test~1.1".to_string(),
-            path: Some(String::from(path_dependency.to_str().unwrap())),
+            path: Some(path_dependency.clone()),
             dry_run: Some(true),
             skip_warnings: None,
         });
@@ -752,7 +748,7 @@ libs = ["dependencies"]
 
         let command = Subcommands::Push(Push {
             dependency: "@test~1.1".to_string(),
-            path: Some(test_dir.to_str().unwrap().to_string()),
+            path: Some(test_dir.clone()),
             dry_run: None,
             skip_warnings: None,
         });
@@ -792,7 +788,7 @@ libs = ["dependencies"]
 
         let command = Subcommands::Push(Push {
             dependency: "@test~1.1".to_string(),
-            path: Some(test_dir.to_str().unwrap().to_string()),
+            path: Some(test_dir.clone()),
             dry_run: None,
             skip_warnings: Some(true),
         });

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -17,7 +17,7 @@ pub struct LockEntry {
     name: String,
     version: String,
     source: String,
-    zip_checksum: String,
+    checksum: String,
 }
 
 impl From<&Dependency> for LockEntry {
@@ -26,7 +26,7 @@ impl From<&Dependency> for LockEntry {
             name: value.name.clone(),
             version: value.version.clone(),
             source: value.url.clone(),
-            zip_checksum: value.hash.clone(),
+            checksum: value.hash.clone(),
         }
     }
 }
@@ -194,13 +194,13 @@ mod tests {
 name = "@openzeppelin-contracts"
 version = "2.3.0"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip"
-zip_checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
+checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
 
 [[dependencies]]
 name = "@prb-test"
 version = "0.6.5"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@prb-test~0.6.5.zip"
-zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#;
         File::create(lock_file).unwrap().write_all(lock_contents.as_bytes()).unwrap();
     }
@@ -261,7 +261,7 @@ zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016
 name = "@openzeppelin-contracts"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
-zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#
         );
         assert!(lock_check(&dependency, true).is_err_and(|e| {
@@ -291,19 +291,19 @@ zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016
 name = "@openzeppelin-contracts"
 version = "2.3.0"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip"
-zip_checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
+checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
 
 [[dependencies]]
 name = "@openzeppelin-contracts-2"
 version = "2.6.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.6.0.zip"
-zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 
 [[dependencies]]
 name = "@prb-test"
 version = "0.6.5"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@prb-test~0.6.5.zip"
-zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#
         );
 
@@ -367,7 +367,7 @@ zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016
 name = "@openzeppelin-contracts2"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
-zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#
         );
     }
@@ -405,7 +405,7 @@ zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016
 name = "@openzeppelin-contracts"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
-zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#
         );
     }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -4,39 +4,156 @@ use crate::{
     utils::{get_current_working_dir, read_file_to_string},
     LOCK_FILE,
 };
-use serde_derive::Deserialize;
+use serde_derive::{Deserialize, Serialize};
 use std::{
     fs::{self, remove_file},
-    io::Write,
     path::PathBuf,
 };
 use yansi::Paint;
 
 // Top level struct to hold the TOML data.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct LockEntry {
     name: String,
     version: String,
     source: String,
-    checksum: String,
+    zip_checksum: String,
 }
 
-impl Clone for LockEntry {
-    fn clone(&self) -> LockEntry {
+impl From<&Dependency> for LockEntry {
+    fn from(value: &Dependency) -> Self {
         LockEntry {
-            name: String::from(&self.name),
-            version: String::from(&self.version),
-            source: String::from(&self.source),
-            checksum: String::from(&self.checksum),
+            name: value.name.clone(),
+            version: value.version.clone(),
+            source: value.url.clone(),
+            zip_checksum: value.hash.clone(),
         }
     }
 }
 
+pub fn lock_check(dependency: &Dependency, create_lock: bool) -> Result<(), LockError> {
+    let lock_entries = match read_lock() {
+        Ok(entries) => entries,
+        Err(_) => {
+            if create_lock {
+                let _ = write_lock(&[], LockWriteMode::Append);
+                return Ok(());
+            }
+            return Err(LockError { cause: "Lock does not exists".to_string() });
+        }
+    };
+
+    let is_locked = lock_entries.iter().any(|lock_entry| {
+        lock_entry.name == dependency.name && lock_entry.version == dependency.version
+    });
+
+    if is_locked {
+        return Err(LockError {
+            cause: format!(
+                "Dependency {}-{} is already installed",
+                dependency.name, dependency.version
+            ),
+        });
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LockWriteMode {
+    Replace,
+    Append,
+}
+
+pub fn write_lock(dependencies: &[Dependency], clean: LockWriteMode) -> Result<(), LockError> {
+    let lock_file: PathBuf = if cfg!(test) {
+        get_current_working_dir().join("test").join("soldeer.lock")
+    } else {
+        LOCK_FILE.clone()
+    };
+
+    if clean == LockWriteMode::Replace && lock_file.exists() {
+        remove_file(&lock_file)
+            .map_err(|_| LockError { cause: "Could not clean lock file".to_string() })?;
+    }
+
+    if !lock_file.exists() {
+        fs::File::create(&lock_file)
+            .map_err(|_| LockError { cause: "Could not create lock file".to_string() })?;
+    }
+
+    let mut entries = read_lock()?;
+    for dep in dependencies {
+        let entry: LockEntry = dep.into();
+        // check for entry already existing
+        match entries.iter().position(|e| e.name == entry.name && e.version == entry.version) {
+            Some(pos) => {
+                // replace the entry with the new data
+                entries[pos] = entry;
+            }
+            None => {
+                println!(
+                    "{}",
+                    Paint::green(&format!(
+                        "Writing {}~{} to the lock file.",
+                        dep.name, dep.version
+                    ))
+                );
+                entries.push(entry);
+            }
+        }
+    }
+    // make sure the ordering is consistent
+    entries.sort_unstable_by(|a, b| a.name.cmp(&b.name).then_with(|| a.version.cmp(&b.version)));
+
+    if entries.is_empty() {
+        // remove lock file if there are no deps left
+        let _ = remove_file(&lock_file);
+        return Ok(());
+    }
+
+    let file_contents = toml::to_string(&LockType { dependencies: entries })
+        .map_err(|_| LockError { cause: "Could not serialize lock file".to_string() })?;
+
+    // replace contents of lockfile with new contents
+    fs::write(lock_file, file_contents)
+        .map_err(|_| LockError { cause: "Could not write to the lock file".to_string() })?;
+    Ok(())
+}
+
+pub fn remove_lock(dependency: &Dependency) -> Result<(), LockError> {
+    let lock_file: PathBuf = if cfg!(test) {
+        get_current_working_dir().join("test").join("soldeer.lock")
+    } else {
+        LOCK_FILE.clone()
+    };
+
+    let entries: Vec<_> = read_lock()?
+        .into_iter()
+        .filter(|e| e.name != dependency.name || e.version != dependency.version)
+        .collect();
+
+    if entries.is_empty() {
+        // remove lock file if there are no deps left
+        let _ = remove_file(&lock_file);
+        return Ok(());
+    }
+
+    let file_contents = toml::to_string(&LockType { dependencies: entries })
+        .map_err(|_| LockError { cause: "Could not serialize lock file".to_string() })?;
+
+    // replace contents of lockfile with new contents
+    fs::write(lock_file, file_contents)
+        .map_err(|_| LockError { cause: "Could not write to the lock file".to_string() })?;
+
+    Ok(())
+}
+
 // Top level struct to hold the TOML data.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 struct LockType {
     dependencies: Vec<LockEntry>,
 }
+
 fn read_lock() -> Result<Vec<LockEntry>, LockError> {
     let lock_file: PathBuf = if cfg!(test) {
         get_current_working_dir().join("test").join("soldeer.lock")
@@ -47,136 +164,12 @@ fn read_lock() -> Result<Vec<LockEntry>, LockError> {
     if !lock_file.exists() {
         return Err(LockError { cause: "Lock does not exists".to_string() });
     }
-    let lock_path: String = lock_file.to_str().unwrap().to_string();
 
-    let contents = read_file_to_string(&lock_path);
+    let contents = read_file_to_string(lock_file);
 
     // reading the contents into a data structure using toml::from_str
-    let data: LockType = match toml::from_str(&contents) {
-        Ok(d) => d,
-        Err(_err) => {
-            return Ok(vec![]);
-        }
-    };
+    let data: LockType = toml::from_str(&contents).unwrap_or_default();
     Ok(data.dependencies)
-}
-
-pub fn lock_check(
-    dependency: &Dependency,
-    create_lock: bool,
-) -> Result<Vec<Dependency>, LockError> {
-    let lock_entries = match read_lock() {
-        Ok(entries) => entries,
-        Err(_) => {
-            if create_lock {
-                let _ = write_lock(&[], false)
-                    .map_err(|_| LockError { cause: "Could not write lock file".to_string() });
-                vec![]
-            } else {
-                return Err(LockError { cause: "Lock does not exists".to_string() });
-            }
-        }
-    };
-
-    let mut unlock_dependencies: Vec<Dependency> = Vec::new();
-    let mut is_locked: bool = false;
-    let mut string_err = String::new();
-    lock_entries.iter().for_each(|lock_entry| {
-        if lock_entry.name == dependency.name && lock_entry.version == dependency.version {
-            string_err = format!(
-                "Dependency {}-{} is already installed",
-                lock_entry.name, lock_entry.version
-            );
-            is_locked = true;
-        }
-    });
-
-    unlock_dependencies.push(dependency.clone());
-
-    if is_locked {
-        return Err(LockError { cause: string_err });
-    }
-    Ok(unlock_dependencies)
-}
-
-pub fn write_lock(dependencies: &[Dependency], clean: bool) -> Result<(), LockError> {
-    let lock_file: PathBuf = if cfg!(test) {
-        get_current_working_dir().join("test").join("soldeer.lock")
-    } else {
-        LOCK_FILE.clone()
-    };
-
-    if clean && (lock_file).exists() {
-        match remove_file(&lock_file) {
-            Ok(_) => {}
-            Err(_) => return Err(LockError { cause: "Could not clean lock file".to_string() }),
-        }
-    }
-
-    if !lock_file.exists() {
-        std::fs::File::create(lock_file.to_str().unwrap()).unwrap();
-    }
-
-    let mut new_lock_entries: String = String::new();
-    dependencies.iter().for_each(|dependency| {
-        new_lock_entries.push_str(&format!(
-            r#"
-[[dependencies]]
-name = "{}"
-version = "{}"
-source = "{}"
-checksum = "{}"
-"#,
-            dependency.name, dependency.version, dependency.url, dependency.hash
-        ));
-        println!(
-            "{}",
-            Paint::green(&format!(
-                "Writing {}~{} to the lock file.",
-                &dependency.name.to_string(),
-                &dependency.version.to_string()
-            ))
-        );
-    });
-    let mut file: std::fs::File = fs::OpenOptions::new().append(true).open(lock_file).unwrap();
-    if write!(file, "{}", new_lock_entries).is_err() {
-        return Err(LockError { cause: "Could not write to the lock file".to_string() });
-    }
-    Ok(())
-}
-
-pub fn remove_lock(dependency_name: &str, dependency_version: &str) -> Result<(), LockError> {
-    let lock_file: PathBuf = if cfg!(test) {
-        get_current_working_dir().join("test").join("soldeer.lock")
-    } else {
-        LOCK_FILE.clone()
-    };
-
-    let entries = match read_lock() {
-        Ok(entries) => entries,
-        Err(err) => return Err(err),
-    };
-    let mut new_lock_entries: String = String::new();
-    entries.iter().for_each(|entry| {
-        if entry.name != dependency_name || entry.version != dependency_version {
-            new_lock_entries.push_str(&format!(
-                r#"
-[[dependencies]]
-name = "{}"
-version = "{}"
-source = "{}"
-checksum = "{}"
-"#,
-                &entry.name, &entry.version, &entry.source, &entry.checksum
-            ));
-        }
-    });
-    let mut file: std::fs::File =
-        fs::OpenOptions::new().truncate(true).write(true).open(lock_file).unwrap();
-    if write!(file, "{}", new_lock_entries).is_err() {
-        return Err(LockError { cause: "Could not write to the lock file".to_string() });
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -201,13 +194,13 @@ mod tests {
 name = "@openzeppelin-contracts"
 version = "2.3.0"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip"
-checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
-                    
+zip_checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
+
 [[dependencies]]
 name = "@prb-test"
 version = "0.6.5"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@prb-test~0.6.5.zip"
-checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#;
         File::create(lock_file).unwrap().write_all(lock_contents.as_bytes()).unwrap();
     }
@@ -256,20 +249,19 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
         };
         let dependencies = vec![dependency.clone()];
-        write_lock(&dependencies, false).unwrap();
+        write_lock(&dependencies, LockWriteMode::Append).unwrap();
         assert!(lock_check(&dependency, true).is_err_and(|e| {
             e.cause == "Dependency @openzeppelin-contracts-2.5.0 is already installed"
         }));
-        let contents = read_file_to_string(&lock_file.to_str().unwrap().to_string());
+        let contents = read_file_to_string(lock_file);
 
         assert_eq!(
             contents,
-            r#"
-[[dependencies]]
+            r#"[[dependencies]]
 name = "@openzeppelin-contracts"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
-checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#
         );
         assert!(lock_check(&dependency, true).is_err_and(|e| {
@@ -290,29 +282,28 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
         };
         dependencies.push(dependency.clone());
-        write_lock(&dependencies, false).unwrap();
-        let contents = read_file_to_string(&lock_file.to_str().unwrap().to_string());
+        write_lock(&dependencies, LockWriteMode::Append).unwrap();
+        let contents = read_file_to_string(lock_file);
 
         assert_eq!(
             contents,
-            r#"
-[[dependencies]]
+            r#"[[dependencies]]
 name = "@openzeppelin-contracts"
 version = "2.3.0"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip"
-checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
-                    
-[[dependencies]]
-name = "@prb-test"
-version = "0.6.5"
-source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@prb-test~0.6.5.zip"
-checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+zip_checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
 
 [[dependencies]]
 name = "@openzeppelin-contracts-2"
 version = "2.6.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.6.0.zip"
-checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+
+[[dependencies]]
+name = "@prb-test"
+version = "0.6.5"
+source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@prb-test~0.6.5.zip"
+zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#
         );
 
@@ -332,17 +323,15 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
         };
         let dependencies = vec![dependency.clone()];
-        write_lock(&dependencies, false).unwrap();
+        write_lock(&dependencies, LockWriteMode::Append).unwrap();
 
-        match remove_lock(&dependency.name, &dependency.version) {
+        match remove_lock(&dependency) {
             Ok(_) => {}
             Err(_) => {
                 assert_eq!("Invalid State", "");
             }
         }
-        let contents = read_file_to_string(&lock_file.to_str().unwrap().to_string());
-
-        assert_eq!(contents, "".to_string());
+        assert!(!lock_file.exists());
     }
 
     #[test]
@@ -362,24 +351,23 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             hash: "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
         };
         let dependencies = vec![dependency.clone(), dependency2.clone()];
-        write_lock(&dependencies, false).unwrap();
+        write_lock(&dependencies, LockWriteMode::Append).unwrap();
 
-        match remove_lock(&dependency.name, &dependency.version) {
+        match remove_lock(&dependency) {
             Ok(_) => {}
             Err(_) => {
                 assert_eq!("Invalid State", "");
             }
         }
-        let contents = read_file_to_string(&lock_file.to_str().unwrap().to_string());
+        let contents = read_file_to_string(lock_file);
 
         assert_eq!(
             contents,
-            r#"
-[[dependencies]]
+            r#"[[dependencies]]
 name = "@openzeppelin-contracts2"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
-checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#
         );
     }
@@ -396,24 +384,28 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
         };
 
         let dependencies = vec![dependency.clone()];
-        write_lock(&dependencies, false).unwrap();
+        write_lock(&dependencies, LockWriteMode::Append).unwrap();
 
-        match remove_lock("non-existent", &dependency.version) {
+        match remove_lock(&Dependency {
+            name: "non-existent".to_string(),
+            version: dependency.version.clone(),
+            url: String::new(),
+            hash: String::new(),
+        }) {
             Ok(_) => {}
             Err(_) => {
                 assert_eq!("Invalid State", "");
             }
         }
-        let contents = read_file_to_string(&lock_file.to_str().unwrap().to_string());
+        let contents = read_file_to_string(lock_file);
 
         assert_eq!(
             contents,
-            r#"
-[[dependencies]]
+            r#"[[dependencies]]
 name = "@openzeppelin-contracts"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
-checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+zip_checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
 "#
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,6 @@ use std::{
     fs::{self, File},
     io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
-    process::exit,
 };
 use yansi::Paint;
 
@@ -14,20 +13,14 @@ pub fn get_current_working_dir() -> PathBuf {
     env::current_dir().unwrap()
 }
 
-pub fn read_file_to_string(path: &String) -> String {
-    let contents: String = match fs::read_to_string(path) {
-        // If successful return the files text as `contents`.
-        // `c` is a local variable.
-        Ok(c) => c,
-        // Handle the `error` case.
-        Err(_) => {
-            // Write `msg` to `stderr`.
-            eprintln!("Could not read file `{}`", path);
-            // Exit the program with exit code `1`.
-            exit(1);
-        }
-    };
-    contents
+/// Read contents of file at path into a string, or panic
+///
+/// # Panics
+/// If the file cannot be read, due to it being non-existent, not a valid UTF-8 string, etc.
+pub fn read_file_to_string(path: impl AsRef<Path>) -> String {
+    fs::read_to_string(path.as_ref()).unwrap_or_else(|_| {
+        panic!("Could not read file `{:?}`", path.as_ref());
+    })
 }
 
 // read a file contents into a vector of bytes so we can unzip it


### PR DESCRIPTION
In preparation for improvements on the lockfile and caching topics, I refactored most of the `lock` module and some other things I spotted in various modules.

- More idiomatic Rust syntax
- Better handling of `PathBuf` in various locations
- Lock file is now sorted for minimizing git diffs when updating it
- In case a dependency is added again but was already present in the lock file, the new data will replace the existing data inside the lock file
- Changed the parameters to some functions for clarity

### Breaking changes

- `janitor::healthcheck_dependency` now takes a reference to `Dependency` instead of name and version
- `janitor::cleanup_dependency` now takes a reference to `Dependency` instead of name and version, and a `CleanupParams` struct as second argument instead of two booleans
- `lock::write_lock` now takes an enum as second parameter to replace the `bool`

