### PR TITLE
refactor!: big rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/*
 !emptyfile2
 test_push_sensitive
 test_push_skip_sensitive
+.soldeer/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,9 +1542,9 @@ checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "simple-home-dir"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c221cbc8c1ff6bdf949b12cc011456c510ec6840654b444c7374c78e928ce344"
+checksum = "ee786d36d89b647cb282c7253385e4c563f363b83e6cdc5c2737724980a8a6a6"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -1597,7 +1597,6 @@ dependencies = [
  "simple-home-dir",
  "thiserror",
  "tokio",
- "toml",
  "toml_edit",
  "uuid",
  "walkdir",
@@ -1728,18 +1727,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,6 +1595,7 @@ dependencies = [
  "serial_test",
  "sha256",
  "simple-home-dir",
+ "thiserror",
  "tokio",
  "toml",
  "toml_edit",
@@ -1643,18 +1644,18 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,36 +13,35 @@ repository = "https://github.com/mario-eth/soldeer"
 version = "0.2.19"
 
 [dependencies]
-chrono = {version = "0.4.38", default-features = false, features = [
+chrono = { version = "0.4.38", default-features = false, features = [
   "std",
   "serde",
-]}
-clap = {version = "4.5.9", features = ["derive"]}
+] }
+clap = { version = "4.5.9", features = ["derive"] }
 email-address-parser = "2.0.0"
 futures = "0.3.30"
 once_cell = "1.19"
 regex = "1.10.5"
-reqwest = {version = "0.12.5", features = [
+reqwest = { version = "0.12.5", features = [
   "blocking",
   "json",
   "multipart",
   "stream",
-], default-features = false}
+], default-features = false }
 rpassword = "7.3.1"
 serde = "1.0.204"
 serde_derive = "1.0.204"
 serde_json = "1.0.120"
 sha256 = "1.5.0"
-simple-home-dir = "0.3.5"
+simple-home-dir = "0.4.0"
 thiserror = "1.0.63"
-tokio = {version = "1.38.0", features = ["rt-multi-thread", "macros"]}
-toml = "0.8.14"
-toml_edit = "0.22.15"
-uuid = {version = "1.10.0", features = ["serde", "v4"]}
+tokio = { version = "1.38.0", features = ["rt-multi-thread", "macros"] }
+toml_edit = { version = "0.22.15", features = ["serde"] }
+uuid = { version = "1.10.0", features = ["serde", "v4"] }
 walkdir = "2.5.0"
 yansi = "1.0.1"
 yash-fnmatch = "1.1.1"
-zip = {version = "2.1.3", default-features = false, features = ["deflate"]}
+zip = { version = "2.1.3", default-features = false, features = ["deflate"] }
 zip-extract = "0.1.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_derive = "1.0.204"
 serde_json = "1.0.120"
 sha256 = "1.5.0"
 simple-home-dir = "0.3.5"
+thiserror = "1.0.63"
 tokio = {version = "1.38.0", features = ["rt-multi-thread", "macros"]}
 toml = "0.8.14"
 toml_edit = "0.22.15"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -49,7 +49,7 @@ pub async fn login() -> Result<()> {
 }
 
 pub fn get_token() -> Result<String> {
-    let security_file = define_security_file_location();
+    let security_file = define_security_file_location()?;
     let jwt = read_file(security_file);
     match jwt {
         Ok(token) => Ok(String::from_utf8(token)
@@ -76,7 +76,7 @@ async fn execute_login(login: Login) -> Result<()> {
 
     let login_response = req.send().await;
 
-    let security_file = define_security_file_location();
+    let security_file = define_security_file_location()?;
     let response = login_response?;
 
     match response.status() {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -130,7 +130,10 @@ mod tests {
 
         // Request a new server from the pool
         let mut server = mockito::Server::new_async().await;
-        env::set_var("base_url", format!("http://{}", server.host_with_port()));
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", format!("http://{}", server.host_with_port()));
+        }
 
         // Create a mock
         let _ = server
@@ -161,7 +164,10 @@ mod tests {
     #[serial]
     async fn login_401() {
         let mut server = mockito::Server::new_async().await;
-        env::set_var("base_url", format!("http://{}", server.host_with_port()));
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", format!("http://{}", server.host_with_port()));
+        }
 
         let data = r#"
         {
@@ -189,7 +195,11 @@ mod tests {
     #[serial]
     async fn login_500() {
         let mut server = mockito::Server::new_async().await;
-        env::set_var("base_url", format!("http://{}", server.host_with_port()));
+
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", format!("http://{}", server.host_with_port()));
+        }
 
         let data = r#"
         {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,11 +47,10 @@ fn validate_dependency(dep: &str) -> Result<String, String> {
     Example custom url: soldeer install @openzeppelin-contracts~2.3.0 https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v5.0.2.zip
     Example git: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git
     Example git with specified commit: soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73\n",
-    after_help = "For more information, read the README.md",
-    override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
+    after_help = "For more information, read the README.md"
 )]
 pub struct Install {
-    #[arg(value_parser = validate_dependency, value_name = "DEPENDENCY~VERSION")]
+    #[arg(value_parser = validate_dependency, value_name = "<DEPENDENCY>~<VERSION>")]
     pub dependency: Option<String>,
     #[arg(value_name = "URL")]
     pub remote_url: Option<String>,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,8 +25,8 @@ pub enum Subcommands {
 #[clap(after_help = "For more information, read the README.md")]
 pub struct Init {
     /// Clean the Foundry project by removing .gitmodules and the lib directory
-    #[arg(long)]
-    pub clean: Option<bool>,
+    #[arg(long, default_value_t = false)]
+    pub clean: bool,
 }
 
 fn validate_dependency(dep: &str) -> Result<String, String> {
@@ -70,20 +70,18 @@ pub struct Install {
     #[arg(long)]
     pub rev: Option<String>,
 
-    /// Set to true to regenerate the remappings from scratch. This will delete the existing
-    /// remappings. Defaults to false.
-    #[arg(long)]
-    pub regenerate_remappings: Option<bool>,
+    /// If set, this command will delete the existing remappings and re-create them
+    #[arg(long, default_value_t = false)]
+    pub regenerate_remappings: bool,
 }
 
 /// Update dependencies by reading the config file
 #[derive(Debug, Clone, Parser)]
 #[clap(after_help = "For more information, read the README.md")]
 pub struct Update {
-    /// Set to false to keep existing remappings. If true, this will delete the existing
-    /// remappings. Defaults to false.
-    #[arg(long)]
-    pub regenerate_remappings: Option<bool>,
+    /// If set, this command will delete the existing remappings and re-create them
+    #[arg(long, default_value_t = false)]
+    pub regenerate_remappings: bool,
 }
 
 /// Display the version of Soldeer
@@ -119,15 +117,15 @@ pub struct Push {
     /// Example: `soldeer push /path/to/dep`.
     pub path: Option<PathBuf>,
 
-    /// Use this if you want to run a dry run. If true, this will generate a zip file that you can
+    /// Use this if you want to run a dry run. If set, this will generate a zip file that you can
     /// inspect to see what will be pushed.
-    #[arg(short, long)]
-    pub dry_run: Option<bool>,
+    #[arg(short, long, default_value_t = false)]
+    pub dry_run: bool,
 
     /// Use this if you want to skip the warnings that can be triggered when trying to push
     /// dotfiles like .env.
-    #[arg(long)]
-    pub skip_warnings: Option<bool>,
+    #[arg(long, default_value_t = false)]
+    pub skip_warnings: bool,
 }
 
 /// Uninstall a dependency

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -88,6 +88,7 @@ pub struct Update {
     pub regenerate_remappings: Option<bool>,
 }
 
+/// Display the version of Soldeer
 #[derive(Debug, Clone, Parser)]
 pub struct VersionDryRun {}
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -75,7 +75,7 @@ pub struct Install {
     /// Set to true to regenerate the remappings from scratch. This will delete the existing
     /// remappings. Defaults to false.
     #[arg(long)]
-    pub reg_remappings: Option<bool>,
+    pub regenerate_remappings: Option<bool>,
 }
 
 /// Update dependencies by reading the config file
@@ -85,7 +85,7 @@ pub struct Update {
     /// Set to false to keep existing remappings. If true, this will delete the existing
     /// remappings. Defaults to false.
     #[arg(long)]
-    pub reg_remappings: Option<bool>,
+    pub regenerate_remappings: Option<bool>,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -50,9 +50,7 @@ You can install a dependency from the Soldeer repository, a custom URL pointing 
 - **Example from Git:**
   soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git
 - **Example from Git with a specified commit:**
-  soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73
-If you want to regenerate the remappings from scratch, use
-  --reg-remappings true",
+  soldeer install @openzeppelin-contracts~2.3.0 git@github.com:OpenZeppelin/openzeppelin-contracts.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73",
     after_help = "For more information, read the README.md"
 )]
 pub struct Install {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -114,7 +114,7 @@ pub struct Push {
 
     /// Use this if the dependency you want to push is not in the current directory.
     ///
-    /// Example: `soldeer push /path/to/dep`.
+    /// Example: `soldeer push mypkg~0.1.0 /path/to/dep`.
     pub path: Option<PathBuf>,
 
     /// Use this if you want to run a dry run. If set, this will generate a zip file that you can

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -57,7 +57,7 @@ pub struct Install {
     /// The dependency name and version, separated by a tilde.
     ///
     /// If not present, this command will perform `soldeer update`
-    #[arg(value_parser = validate_dependency, value_name = "DEPENDENCY>~<VERSION")]
+    #[arg(value_parser = validate_dependency, value_name = "DEPENDENCY~VERSION")]
     pub dependency: Option<String>,
 
     /// The URL to the dependency zip file, if not from the Soldeer repository

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -32,6 +32,13 @@ pub struct Init {
     pub clean: Option<bool>,
 }
 
+fn validate_dependency(dep: &str) -> Result<String, String> {
+    if dep.split('~').count() != 2 {
+        return Err("The dependency should be in the format <DEPENDENCY>~<VERSION>".to_string());
+    }
+    Ok(dep.to_string())
+}
+
 #[derive(Debug, Clone, Parser)]
 #[clap(
     about = "Install a dependency from Soldeer repository or from a custom url that points to a zip file or from git using a git link.
@@ -44,11 +51,11 @@ pub struct Init {
     override_usage = "soldeer install <DEPENDENCY>~<VERSION> [URL]"
 )]
 pub struct Install {
-    #[clap(required = false)]
+    #[arg(value_parser = validate_dependency, value_name = "DEPENDENCY~VERSION")]
     pub dependency: Option<String>,
-    #[clap(required = false)]
+    #[arg(value_name = "URL")]
     pub remote_url: Option<String>,
-    #[arg(long, value_parser = clap::value_parser!(String))]
+    #[arg(long)]
     pub rev: Option<String>,
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -17,7 +17,7 @@ pub enum Subcommands {
     Login(Login),
     Push(Push),
     Uninstall(Uninstall),
-    VersionDryRun(VersionDryRun),
+    Version(Version),
 }
 
 /// Initialize a new Soldeer project for use with Foundry
@@ -90,7 +90,7 @@ pub struct Update {
 
 /// Display the version of Soldeer
 #[derive(Debug, Clone, Parser)]
-pub struct VersionDryRun {}
+pub struct Version {}
 
 /// Log into the central repository to push the dependencies
 #[derive(Debug, Clone, Parser)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -439,10 +439,15 @@ async fn parse_dependency(
 ) -> Result<Dependency, ConfigError> {
     match parse_dependency_sync(name, value)? {
         Dependency::Http(mut dep) => {
-            let url = get_dependency_url_remote(&dep.name, &dep.version).await.map_err(|_| {
-                ConfigError { cause: format!("Could not retrieve URL for dependency {}", dep.name) }
-            })?;
-            dep.url = Some(url);
+            if dep.url.is_none() {
+                let url =
+                    get_dependency_url_remote(&dep.name, &dep.version).await.map_err(|_| {
+                        ConfigError {
+                            cause: format!("Could not retrieve URL for dependency {}", dep.name),
+                        }
+                    })?;
+                dep.url = Some(url);
+            }
             Ok(Dependency::Http(dep))
         }
         dep => Ok(dep),

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,7 @@ pub struct SoldeerConfig {
     #[serde(default)]
     pub remappings_regenerate: bool,
 
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub remappings_version: bool,
 
     #[serde(default)]
@@ -53,7 +53,7 @@ impl Default for SoldeerConfig {
         SoldeerConfig {
             remappings_generate: true,
             remappings_regenerate: false,
-            remappings_version: false,
+            remappings_version: true,
             remappings_prefix: String::new(),
             remappings_location: Default::default(),
         }
@@ -432,9 +432,13 @@ fn parse_dependency(name: impl Into<String>, value: &Item) -> Result<Dependency>
             return Err(ConfigError::EmptyVersion(name));
         }
         // this function does not retrieve the url
-        return Ok(
-            HttpDependency { name, version: version.to_string(), url: None, checksum: None }.into()
-        );
+        return Ok(HttpDependency {
+            name,
+            version: version.to_string(),
+            url: None,
+            checksum: None,
+        }
+        .into());
     }
 
     // we should have a table or inline table
@@ -1954,7 +1958,7 @@ remappings_generate = true
 [profile.default]
 solc = "0.8.26"
 libs = ["dependencies"]
-remappings = ["dep1/=dependencies/dep1-1.0.0/"]
+remappings = ["dep1-1.0.0/=dependencies/dep1-1.0.0/"]
 [profile.local.testing]
 ffi = true
 [dependencies]
@@ -2004,9 +2008,9 @@ remappings_generate = true
 [profile.default]
 solc = "0.8.26"
 libs = ["dependencies"]
-remappings = ["dep1/=dependencies/dep1-1.0.0/"]
+remappings = ["dep1-1.0.0/=dependencies/dep1-1.0.0/"]
 [profile.local]
-remappings = ["dep1/=dependencies/dep1-1.0.0/"]
+remappings = ["dep1-1.0.0/=dependencies/dep1-1.0.0/"]
 [profile.local.testing]
 ffi = true
 [dependencies]
@@ -2026,7 +2030,7 @@ remappings_generate = true
 [profile.default]
 solc = "0.8.26"
 libs = ["dependencies"]
-remappings = ["dep2/=dependencies/dep2-1.0.0/"]
+remappings = ["dep2-1.0.0/=dependencies/dep2-1.0.0/"]
 [dependencies]
 [soldeer]
 remappings_generate = true
@@ -2053,7 +2057,7 @@ remappings_generate = true
 [profile.default]
 solc = "0.8.26"
 libs = ["dependencies"]
-remappings = ["dep1/=dependencies/dep1-1.0.0/", "dep2/=dependencies/dep2-1.0.0/"]
+remappings = ["dep1-1.0.0/=dependencies/dep1-1.0.0/", "dep2-1.0.0/=dependencies/dep2-1.0.0/"]
 [dependencies]
 [soldeer]
 remappings_generate = true
@@ -2097,7 +2101,7 @@ remappings_regenerate = true
 [profile.default]
 solc = "0.8.26"
 libs = ["dependencies"]
-remappings = ["dep2/=dependencies/dep2-1.0.0/"]
+remappings = ["dep2-1.0.0/=dependencies/dep2-1.0.0/"]
 [dependencies]
 dep2 = "1.0.0"
 [soldeer]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,123 +4,153 @@ use crate::{
     utils::{get_current_working_dir, read_file_to_string, remove_empty_lines},
     FOUNDRY_CONFIG_FILE, SOLDEER_CONFIG_FILE,
 };
-use serde_derive::Deserialize;
+use serde_derive::{Deserialize, Serialize};
 use std::{
     env,
     fs::{self, remove_dir_all, remove_file, File},
-    io,
-    io::Write,
-    path::Path,
+    io::{self, Write},
+    path::{Path, PathBuf},
 };
-use toml::Table;
-use toml_edit::{value, DocumentMut, Item};
+use toml_edit::{value, DocumentMut, Item, Table};
 use yansi::Paint;
 
-// Top level struct to hold the TOML data.
-#[derive(Deserialize, Debug)]
-struct Data {
-    dependencies: Table,
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct GitDependency {
+    pub name: String,
+    pub version: String,
+    pub git: String,
+    pub rev: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct HttpDependency {
+    pub name: String,
+    pub version: String,
+    pub url: Option<String>,
+    pub checksum: Option<Vec<u8>>,
 }
 
 // Dependency object used to store a dependency data
-#[derive(Deserialize, Clone, Debug, PartialEq)]
-pub struct Dependency {
-    pub name: String,
-    pub version: String,
-    pub url: String,
-    pub hash: String,
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum Dependency {
+    Http(HttpDependency),
+    Git(GitDependency),
 }
 
-#[derive(Deserialize, Debug)]
-struct Foundry {
-    remappings: Table,
-}
-
-pub async fn read_config(filename: String) -> Result<Vec<Dependency>, ConfigError> {
-    let mut filename: String = filename;
-    if filename.is_empty() {
-        filename = match define_config_file() {
-            Ok(file) => file,
-            Err(err) => return Err(err),
+impl Dependency {
+    pub fn name(&self) -> &str {
+        match self {
+            Dependency::Http(dep) => &dep.name,
+            Dependency::Git(dep) => &dep.name,
         }
     }
-    let contents = read_file_to_string(&filename);
 
-    // reading the contents into a data structure using toml::from_str
-    let data: Data = match toml::from_str(&contents) {
-        Ok(d) => d,
-        Err(_) => {
-            return Err(ConfigError {
-                cause: format!("Could not read the config file {}", filename),
-            });
+    pub fn version(&self) -> &str {
+        match self {
+            Dependency::Http(dep) => &dep.version,
+            Dependency::Git(dep) => &dep.version,
         }
+    }
+
+    pub fn url(&self) -> Option<&String> {
+        match self {
+            Dependency::Http(dep) => dep.url.as_ref(),
+            Dependency::Git(dep) => Some(&dep.git),
+        }
+    }
+
+    pub fn to_toml_value(&self) -> (String, Item) {
+        match self {
+            Dependency::Http(dep) => (
+                dep.name.clone(),
+                match &dep.url {
+                    Some(url) => {
+                        let mut table = Table::new();
+                        table["version"] = value(&dep.version);
+                        table["url"] = value(url);
+                        Item::Table(table)
+                    }
+                    None => value(&dep.version),
+                },
+            ),
+            Dependency::Git(dep) => (
+                dep.name.clone(),
+                match &dep.rev {
+                    Some(rev) => {
+                        let mut table = Table::new();
+                        table["version"] = value(&dep.version);
+                        table["git"] = value(&dep.git);
+                        table["rev"] = value(rev);
+                        Item::Table(table)
+                    }
+                    None => {
+                        let mut table = Table::new();
+                        table["version"] = value(&dep.version);
+                        table["git"] = value(&dep.git);
+                        Item::Table(table)
+                    }
+                },
+            ),
+        }
+    }
+}
+
+impl From<HttpDependency> for Dependency {
+    fn from(dep: HttpDependency) -> Self {
+        Dependency::Http(dep)
+    }
+}
+
+impl From<GitDependency> for Dependency {
+    fn from(dep: GitDependency) -> Self {
+        Dependency::Git(dep)
+    }
+}
+
+pub async fn read_config(path: Option<PathBuf>) -> Result<Vec<Dependency>, ConfigError> {
+    let path: PathBuf = match path {
+        Some(p) => p,
+        None => get_config_path()?,
+    };
+    let contents = read_file_to_string(&path);
+    let doc: DocumentMut = contents.parse::<DocumentMut>().expect("invalid doc");
+    if !doc.contains_table("dependencies") {
+        return Err(ConfigError {
+            cause: format!("`[dependencies]` is missing from the config file {path:?}"),
+        });
+    }
+    let Some(Some(data)) = doc.get("dependencies").map(|v| v.as_table()) else {
+        return Err(ConfigError {
+            cause: format!("`[dependencies]` is missing from the config file {path:?}"),
+        });
     };
 
     let mut dependencies: Vec<Dependency> = Vec::new();
-    let iterator = data.dependencies.iter();
-    for (name, v) in iterator {
-        #[allow(clippy::needless_late_init)]
-        let url;
-        let version;
-        let mut rev = String::new();
-
-        // checks if the format is dependency = {version = "1.1.1" }
-        if v.get("version").is_some() {
-            // clear any string quotes added by mistake
-            version = v["version"].to_string().replace('"', "");
-        } else {
-            // checks if the format is dependency = "1.1.1"
-            version = String::from(v.as_str().unwrap());
-            if version.is_empty() {
-                return Err(ConfigError {
-                    cause: "Could not get the config correctly from the config file".to_string(),
-                });
-            }
-        }
-
-        if v.get("url").is_some() {
-            // clear any string quotes added by mistake
-            url = v["url"].to_string().replace('\"', "");
-        } else if v.get("git").is_some() {
-            url = v["git"].to_string().replace('\"', "");
-            if v.get("rev").is_some() {
-                rev = v["rev"].to_string().replace('\"', "");
-            }
-        } else {
-            // we don't have a specified url, means we will rely on the remote server to give it to
-            // us
-            url = match get_dependency_url_remote(name, &version).await {
-                Ok(u) => u,
-                Err(_) => {
-                    return Err(ConfigError { cause: "Could not get the url".to_string() });
-                }
-            }
-        }
-
-        dependencies.push(Dependency { name: name.to_string(), version, url, hash: rev });
+    for (name, v) in data {
+        dependencies.push(parse_dependency(name, v).await?);
     }
-
     Ok(dependencies)
 }
 
-pub fn define_config_file() -> Result<String, ConfigError> {
-    let mut filename: String;
-    if cfg!(test) {
-        filename =
-            env::var("config_file").unwrap_or(String::from(FOUNDRY_CONFIG_FILE.to_str().unwrap()))
+pub fn get_config_path() -> Result<PathBuf, ConfigError> {
+    let foundry_path: PathBuf = if cfg!(test) {
+        env::var("config_file").map(|s| s.into()).unwrap_or(FOUNDRY_CONFIG_FILE.clone())
     } else {
-        filename = String::from(FOUNDRY_CONFIG_FILE.to_str().unwrap());
+        FOUNDRY_CONFIG_FILE.clone()
     };
 
-    // check if the foundry.toml has the dependencies defined, if so then we setup the foundry.toml
-    // as the config file
-    if fs::metadata(&filename).is_ok() {
-        return Ok(filename);
+    if let Ok(contents) = fs::read_to_string(&foundry_path) {
+        let doc: DocumentMut = contents.parse::<DocumentMut>().expect("invalid doc");
+        if doc.contains_table("dependencies") {
+            return Ok(foundry_path);
+        }
     }
 
-    filename = String::from(SOLDEER_CONFIG_FILE.to_str().unwrap());
-    match fs::metadata(&filename) {
-        Ok(_) => {}
+    let soldeer_path = SOLDEER_CONFIG_FILE.clone();
+    match fs::metadata(&soldeer_path) {
+        Ok(_) => {
+            return Ok(soldeer_path);
+        }
         Err(_) => {
             println!("{}", Paint::blue("No config file found. If you wish to proceed, please select how you want Soldeer to be configured:\n1. Using foundry.toml\n2. Using soldeer.toml\n(Press 1 or 2), default is foundry.toml"));
             std::io::stdout().flush().unwrap();
@@ -135,65 +165,38 @@ pub fn define_config_file() -> Result<String, ConfigError> {
             return create_example_config(&option);
         }
     }
-
-    Ok(filename)
 }
 
 pub fn add_to_config(
     dependency: &Dependency,
-    custom_url: bool,
-    config_file: &str,
-    via_git: bool,
+    config_path: impl AsRef<Path>,
 ) -> Result<(), ConfigError> {
     println!(
         "{}",
         Paint::green(&format!(
             "Adding dependency {}-{} to the config file",
-            dependency.name, dependency.version
+            dependency.name(),
+            dependency.version()
         ))
     );
 
-    let contents = read_file_to_string(config_file);
+    let contents = read_file_to_string(&config_path);
     let mut doc: DocumentMut = contents.parse::<DocumentMut>().expect("invalid doc");
 
-    // in case we don't have dependencies defined in the config file, we add it and re-read the doc
+    // in case we don't have the dependencies section defined in the config file, we add it
     if !doc.contains_table("dependencies") {
-        let mut file: std::fs::File =
-            fs::OpenOptions::new().append(true).open(config_file).unwrap();
-        if let Err(e) = write!(file, "{}", String::from("\n[dependencies]\n")) {
-            eprintln!("Couldn't write to the config file: {}", e);
-        }
-
-        doc = read_file_to_string(config_file).parse::<DocumentMut>().expect("invalid doc");
-    }
-    let mut new_dependencies: String = String::new();
-
-    new_dependencies.push_str(&format!(
-        "  \"{}~{}\" = \"{}\"\n",
-        dependency.name, dependency.version, dependency.url
-    ));
-
-    let mut new_item: Item = Item::None;
-    if custom_url && !via_git {
-        new_item["version"] = value(dependency.version.clone());
-        new_item["url"] = value(dependency.url.clone());
-    } else if via_git {
-        new_item["version"] = value(dependency.version.clone());
-        new_item["git"] = value(dependency.url.clone());
-        new_item["rev"] = value(dependency.hash.clone());
-    } else {
-        new_item = value(dependency.version.clone())
+        doc.insert("dependencies", Item::Table(Table::default()));
     }
 
+    let (name, value) = dependency.to_toml_value();
     doc["dependencies"]
         .as_table_mut()
-        .unwrap()
-        .insert(dependency.name.to_string().as_str(), new_item);
-    let mut file: std::fs::File =
-        fs::OpenOptions::new().write(true).append(false).truncate(true).open(config_file).unwrap();
-    if let Err(e) = write!(file, "{}", doc) {
-        eprintln!("Couldn't write to the config file: {}", e);
-    }
+        .expect("dependencies should be a table")
+        .insert(&name, value);
+
+    fs::write(config_path, doc.to_string())
+        .map_err(|e| ConfigError { cause: format!("Couldn't write to the config file: {e:?}") })?;
+
     Ok(())
 }
 
@@ -207,7 +210,7 @@ pub async fn remappings() -> Result<(), ConfigError> {
     let existing_remappings: Vec<String> = contents.split('\n').map(|s| s.to_string()).collect();
     let mut new_remappings: String = String::new();
 
-    let dependencies: Vec<Dependency> = match read_config(String::new()).await {
+    let dependencies: Vec<Dependency> = match read_config(None).await {
         Ok(dep) => dep,
         Err(err) => {
             return Err(err);
@@ -225,7 +228,8 @@ pub async fn remappings() -> Result<(), ConfigError> {
     });
 
     dependencies.iter().for_each(|dependency| {
-        let mut dependency_name_formatted = format!("{}-{}", &dependency.name, &dependency.version);
+        let mut dependency_name_formatted =
+            format!("{}-{}", &dependency.name(), &dependency.version());
         if !dependency_name_formatted.contains('@') {
             dependency_name_formatted = format!("@{}", dependency_name_formatted);
         }
@@ -240,7 +244,9 @@ pub async fn remappings() -> Result<(), ConfigError> {
             );
             new_remappings.push_str(&format!(
                 "\n{}=dependencies/{}-{}",
-                &dependency_name_formatted, &dependency.name, &dependency.version
+                &dependency_name_formatted,
+                &dependency.name(),
+                &dependency.version()
             ));
         }
     });
@@ -263,84 +269,36 @@ pub async fn remappings() -> Result<(), ConfigError> {
     Ok(())
 }
 
-pub fn get_foundry_setup() -> Result<Vec<bool>, ConfigError> {
-    let filename = match define_config_file() {
-        Ok(file) => file,
-        Err(err) => {
-            return Err(err);
-        }
-    };
-    if filename.contains("foundry.toml") {
-        return Ok(vec![true]);
-    }
-    let contents: String = read_file_to_string(&filename);
-
-    // reading the contents into a data structure using toml::from_str
-    let data: Foundry = match toml::from_str(&contents) {
-        Ok(d) => d,
-        Err(_) => {
-            println!(
-                "{}",
-                Paint::yellow(&"The remappings field not found in the soldeer.toml and no foundry config file found or the foundry.toml does not contain the `[dependencies]` field.\nThe foundry.toml file should contain the `[dependencies]` field if you want to use it as a config file. If you want to use the soldeer.toml file, please add the `[remappings]` field to it with the `enabled` key set to `true` or `false`.\nMore info on https://github.com/mario-eth/soldeer\nThe installation was successful but the remappings feature was skipped.".to_string())
-            );
-            return Ok(vec![false]);
-        }
-    };
-    if data.remappings.get("enabled").is_none() {
-        println!(
-            "{}",
-            Paint::yellow(&"The remappings field not found in the soldeer.toml and no foundry config file found or the foundry.toml does not contain the `[dependencies]` field.\nThe foundry.toml file should contain the `[dependencies]` field if you want to use it as a config file. If you want to use the soldeer.toml file, please add the `[remappings]` field to it with the `enabled` key set to `true` or `false`.\nMore info on https://github.com/mario-eth/soldeer\nThe installation was successful but the remappings feature was skipped.".to_string())
-        );
-        return Ok(vec![false]);
-    }
-    Ok(vec![data.remappings.get("enabled").unwrap().as_bool().unwrap()])
-}
-
 pub fn delete_config(
-    dependency_name: &String,
-    config_file: &str,
+    dependency_name: &str,
+    path: impl AsRef<Path>,
 ) -> Result<Dependency, ConfigError> {
     println!(
         "{}",
-        Paint::green(&format!("Removing the dependency {} from the config file", dependency_name))
+        Paint::green(&format!("Removing the dependency {dependency_name} from the config file"))
     );
 
-    let contents = read_file_to_string(config_file);
+    let contents = read_file_to_string(&path);
     let mut doc: DocumentMut = contents.parse::<DocumentMut>().expect("invalid doc");
 
     if !doc.contains_table("dependencies") {
         return Err(ConfigError {
-            cause: format!("Could not read the config file {}", config_file),
+            cause: format!("`[dependencies]` is missing from the config file {:?}", path.as_ref()),
         });
     }
 
-    let item_removed = doc["dependencies"].as_table_mut().unwrap().remove(dependency_name);
-
-    if item_removed.is_none() {
+    let Some(item_removed) = doc["dependencies"].as_table_mut().unwrap().remove(dependency_name)
+    else {
         return Err(ConfigError {
-            cause: format!("The dependency {} does not exists in the config file", dependency_name),
+            cause: format!("The dependency {dependency_name} does not exists in the config file"),
         });
-    }
-
-    let dependency = Dependency {
-        name: dependency_name.clone(),
-        version: item_removed
-            .unwrap()
-            .as_value()
-            .unwrap()
-            .to_string()
-            .replace("\"", "")
-            .trim()
-            .to_string(),
-        hash: "".to_string(),
-        url: "".to_string(),
     };
 
-    let mut file: std::fs::File =
-        fs::OpenOptions::new().write(true).append(false).truncate(true).open(config_file).unwrap();
-    if let Err(e) = write!(file, "{}", doc) {
-        return Err(ConfigError { cause: format!("Couldn't write to the config file {}", e) });
-    }
+    let dependency = parse_dependency_sync(dependency_name, &item_removed)?;
+
+    fs::write(path, doc.to_string())
+        .map_err(|e| ConfigError { cause: format!("Couldn't write to the config file: {e:?}") })?;
+
     Ok(dependency)
 }
 
@@ -353,12 +311,110 @@ pub fn remove_forge_lib() -> Result<(), ConfigError> {
     Ok(())
 }
 
-fn create_example_config(option: &str) -> Result<String, ConfigError> {
-    let config_file: &str;
-    let content: &str;
-    if option.trim() == "1" {
-        config_file = FOUNDRY_CONFIG_FILE.to_str().unwrap();
-        content = r#"
+/// This function parses the TOML config item into a Dependency object but doesn't retrieve the URL
+/// in case of an HTTP dependency with only a version string.
+fn parse_dependency_sync(name: impl Into<String>, value: &Item) -> Result<Dependency, ConfigError> {
+    let name: String = name.into();
+    if let Some(version) = value.as_str() {
+        // this function does not retrieve the url
+        return Ok(Dependency::Http(HttpDependency {
+            name,
+            version: version.to_string(),
+            url: None,
+            checksum: None,
+        }));
+    }
+
+    // we should have a table
+    let Some(table) = value.as_table() else {
+        return Err(ConfigError { cause: format!("Config for {name} is invalid") });
+    };
+
+    // version is needed in both cases
+    let version = match table.get("version").map(|v| v.as_str()) {
+        Some(None) => {
+            return Err(ConfigError {
+                cause: format!("Field `version` for dependency {name} is invalid"),
+            });
+        }
+        None => {
+            return Err(ConfigError {
+                cause: format!("Field `version` for dependency {name} is missing"),
+            });
+        }
+        Some(Some(version)) => version.to_string(),
+    };
+
+    // check if it's a git dependency
+    match table.get("git").map(|v| v.as_str()) {
+        Some(None) => {
+            return Err(ConfigError {
+                cause: format!("Field `git` for dependency {name} is invalid"),
+            });
+        }
+        Some(Some(git)) => {
+            // rev field is optional but needs to be a string if present
+            let rev = match table.get("rev").map(|v| v.as_str()) {
+                Some(Some(rev)) => Some(rev.to_string()),
+                Some(None) => {
+                    return Err(ConfigError {
+                        cause: format!("Field `rev` for dependency {name} is invalid"),
+                    });
+                }
+                None => None,
+            };
+            return Ok(Dependency::Git(GitDependency {
+                name: name.to_string(),
+                git: git.to_string(),
+                version,
+                rev,
+            }));
+        }
+        None => {}
+    }
+
+    // we should have a HTTP dependency
+    match table.get("url").map(|v| v.as_str()) {
+        Some(None) => {
+            return Err(ConfigError {
+                cause: format!("Field `url` for dependency {name} is invalid"),
+            });
+        }
+        None => {
+            return Err(ConfigError {
+                cause: format!("Field `url` for dependency {name} is missing"),
+            });
+        }
+        Some(Some(url)) => Ok(Dependency::Http(HttpDependency {
+            name: name.to_string(),
+            version,
+            url: Some(url.to_string()),
+            checksum: None,
+        })),
+    }
+}
+
+async fn parse_dependency(
+    name: impl Into<String>,
+    value: &Item,
+) -> Result<Dependency, ConfigError> {
+    match parse_dependency_sync(name, value)? {
+        Dependency::Http(mut dep) => {
+            let url = get_dependency_url_remote(&dep.name, &dep.version).await.map_err(|_| {
+                ConfigError { cause: format!("Could not retrieve URL for dependency {}", dep.name) }
+            })?;
+            dep.url = Some(url);
+            Ok(Dependency::Http(dep))
+        }
+        dep => Ok(dep),
+    }
+}
+
+fn create_example_config(option: &str) -> Result<PathBuf, ConfigError> {
+    let (config_path, contents) = match option.trim() {
+        "1" => (
+            FOUNDRY_CONFIG_FILE.clone(),
+            r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
 [profile.default]
@@ -369,29 +425,25 @@ test = "test"
 libs = ["dependencies"]
 
 [dependencies]
-"#;
-    } else if option.trim() == "2" {
-        config_file = SOLDEER_CONFIG_FILE.to_str().unwrap();
-        content = r#"
+"#,
+        ),
+        "2" => (
+            SOLDEER_CONFIG_FILE.clone(),
+            r#"
 [remappings]
 enabled = true
 
 [dependencies]
-"#;
-    } else {
-        return Err(ConfigError { cause: "Option invalid".to_string() });
-    }
+"#,
+        ),
+        _ => {
+            return Err(ConfigError { cause: "Invalid option".to_string() });
+        }
+    };
 
-    std::fs::File::create(config_file).unwrap();
-    let mut file: std::fs::File = fs::OpenOptions::new().write(true).open(config_file).unwrap();
-    if write!(file, "{}", content).is_err() {
-        return Err(ConfigError { cause: "Could not create a new config file".to_string() });
-    }
-    let mut filename = String::from(FOUNDRY_CONFIG_FILE.to_str().unwrap());
-    if option.trim() == "2" {
-        filename = String::from(SOLDEER_CONFIG_FILE.to_str().unwrap());
-    }
-    Ok(filename)
+    fs::write(&config_path, contents)
+        .map_err(|e| ConfigError { cause: format!("Could not create a new config file: {e:?}") })?;
+    Ok(config_path)
 }
 
 ////////////// TESTS //////////////
@@ -443,7 +495,7 @@ libs = ["dependencies"]
 
         ////////////// END-MOCK //////////////
 
-        let result = match read_config(String::from(target_config.to_str().unwrap())).await {
+        let result = match read_config(Some(target_config.clone())).await {
             Ok(dep) => dep,
             Err(err) => {
                 return Err(err);
@@ -452,22 +504,22 @@ libs = ["dependencies"]
 
         assert_eq!(
             result[0],
-            Dependency {
+            Dependency::Http(HttpDependency {
                 name: "@gearbox-protocol-periphery-v3".to_string(),
                 version: "1.6.1".to_string(),
-                url: "https://example_url.com/example_url.zip".to_string(),
-                hash: String::new()
-            }
+                url: Some("https://example_url.com/example_url.zip".to_string()),
+                checksum: None
+            })
         );
 
         assert_eq!(
             result[1],
-            Dependency {
+            Dependency::Http(HttpDependency {
                 name: "@openzeppelin-contracts".to_string(),
                 version: "5.0.2".to_string(),
-                url: "https://example_url.com/example_url.zip".to_string(),
-                hash: String::new()
-            }
+                url: Some("https://example_url.com/example_url.zip".to_string()),
+                checksum: None
+            })
         );
         let _ = remove_file(target_config);
         Ok(())
@@ -505,7 +557,7 @@ libs = ["dependencies"]
 
         ////////////// END-MOCK //////////////
 
-        let result = match read_config(String::from(target_config.to_str().unwrap())).await {
+        let result = match read_config(Some(target_config.clone())).await {
             Ok(dep) => dep,
             Err(err) => {
                 return Err(err);
@@ -514,22 +566,22 @@ libs = ["dependencies"]
 
         assert_eq!(
             result[0],
-            Dependency {
+            Dependency::Http(HttpDependency {
                 name: "@gearbox-protocol-periphery-v3".to_string(),
                 version: "1.6.1".to_string(),
-                url: "https://example_url.com/example_url.zip".to_string(),
-                hash: String::new()
-            }
+                url: Some("https://example_url.com/example_url.zip".to_string()),
+                checksum: None
+            })
         );
 
         assert_eq!(
             result[1],
-            Dependency {
+            Dependency::Http(HttpDependency {
                 name: "@openzeppelin-contracts".to_string(),
                 version: "5.0.2".to_string(),
-                url: "https://example_url.com/example_url.zip".to_string(),
-                hash: String::new()
-            }
+                url: Some("https://example_url.com/example_url.zip".to_string()),
+                checksum: None
+            })
         );
         let _ = remove_file(target_config);
         Ok(())
@@ -565,7 +617,7 @@ enabled = true
 
         ////////////// END-MOCK //////////////
 
-        let result = match read_config(String::from(target_config.to_str().unwrap())).await {
+        let result = match read_config(Some(target_config.clone())).await {
             Ok(dep) => dep,
             Err(err) => {
                 return Err(err);
@@ -574,22 +626,22 @@ enabled = true
 
         assert_eq!(
             result[0],
-            Dependency {
+            Dependency::Http(HttpDependency {
                 name: "@gearbox-protocol-periphery-v3".to_string(),
                 version: "1.6.1".to_string(),
-                url: "https://example_url.com/example_url.zip".to_string(),
-                hash: String::new()
-            }
+                url: Some("https://example_url.com/example_url.zip".to_string()),
+                checksum: None
+            })
         );
 
         assert_eq!(
             result[1],
-            Dependency {
+            Dependency::Http(HttpDependency {
                 name: "@openzeppelin-contracts".to_string(),
                 version: "5.0.2".to_string(),
-                url: "https://example_url.com/example_url.zip".to_string(),
-                hash: String::new()
-            }
+                url: Some("https://example_url.com/example_url.zip".to_string()),
+                checksum: None
+            })
         );
         let _ = remove_file(target_config);
         Ok(())
@@ -625,7 +677,7 @@ enabled = true
 
         ////////////// END-MOCK //////////////
 
-        let result = match read_config(String::from(target_config.to_str().unwrap())).await {
+        let result = match read_config(Some(target_config.clone())).await {
             Ok(dep) => dep,
             Err(err) => {
                 return Err(err);
@@ -634,22 +686,22 @@ enabled = true
 
         assert_eq!(
             result[0],
-            Dependency {
+            Dependency::Http(HttpDependency {
                 name: "@gearbox-protocol-periphery-v3".to_string(),
                 version: "1.6.1".to_string(),
-                url: "https://example_url.com/example_url.zip".to_string(),
-                hash: String::new()
-            }
+                url: Some("https://example_url.com/example_url.zip".to_string()),
+                checksum: None
+            })
         );
 
         assert_eq!(
             result[1],
-            Dependency {
+            Dependency::Http(HttpDependency {
                 name: "@openzeppelin-contracts".to_string(),
                 version: "5.0.2".to_string(),
-                url: "https://example_url.com/example_url.zip".to_string(),
-                hash: String::new()
-            }
+                url: Some("https://example_url.com/example_url.zip".to_string()),
+                checksum: None
+            })
         );
         let _ = remove_file(target_config);
         Ok(())
@@ -671,7 +723,7 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, config_contents);
 
-        match read_config(String::from(target_config.clone().to_str().unwrap())).await {
+        match read_config(Some(target_config.clone())).await {
             Ok(_) => {
                 assert_eq!("False state", "");
             }
@@ -707,7 +759,7 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, config_contents);
 
-        match read_config(String::from(target_config.clone().to_str().unwrap())).await {
+        match read_config(Some(target_config.clone())).await {
             Ok(_) => {
                 assert_eq!("False state", "");
             }
@@ -741,7 +793,7 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, config_contents);
 
-        match read_config(String::from(target_config.clone().to_str().unwrap())).await {
+        match read_config(Some(target_config.clone())).await {
             Ok(_) => {
                 assert_eq!("False state", "");
             }
@@ -844,13 +896,13 @@ libs = ["dependencies"]
         let target_config = define_config(true);
 
         write_to_config(&target_config, content);
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
-        add_to_config(&dependency, false, target_config.to_str().unwrap(), false).unwrap();
+            url: None,
+            checksum: None,
+        });
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -890,14 +942,14 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: Some("http://custom_url.com/custom.zip".to_string()),
+            checksum: None,
+        });
 
-        add_to_config(&dependency, true, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -938,14 +990,14 @@ old_dep = "5.1.0-my-version-is-cool"
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: None,
+            checksum: None,
+        });
 
-        add_to_config(&dependency, false, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -987,14 +1039,14 @@ old_dep = { version = "5.1.0-my-version-is-cool", url = "http://custom_url.com/c
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: Some("http://custom_url.com/custom.zip".to_string()),
+            checksum: None,
+        });
 
-        add_to_config(&dependency, true, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -1036,14 +1088,14 @@ old_dep = { version = "5.1.0-my-version-is-cool", url = "http://custom_url.com/c
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "old_dep".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: Some("http://custom_url.com/custom.zip".to_string()),
+            checksum: None,
+        });
 
-        add_to_config(&dependency, true, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -1084,14 +1136,14 @@ old_dep = { version = "5.1.0-my-version-is-cool", url = "http://custom_url.com/c
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "old_dep".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: None,
+            checksum: None,
+        });
 
-        add_to_config(&dependency, false, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -1132,14 +1184,14 @@ gas_reports = ['*']
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: None,
+            checksum: None,
+        });
 
-        add_to_config(&dependency, false, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -1176,14 +1228,14 @@ enabled = true
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: None,
+            checksum: None,
+        });
 
-        add_to_config(&dependency, false, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 [remappings]
 enabled = true
@@ -1211,14 +1263,14 @@ enabled = true
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: Some("http://custom_url.com/custom.zip".to_string()),
+            checksum: None,
+        });
 
-        add_to_config(&dependency, true, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 [remappings]
 enabled = true
@@ -1253,14 +1305,14 @@ gas_reports = ['*']
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Git(GitDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "git@github.com:foundry-rs/forge-std.git".to_string(),
-            hash: "07263d193d621c4b2b0ce8b4d54af58f6957d97d".to_string(),
-        };
+            git: "git@github.com:foundry-rs/forge-std.git".to_string(),
+            rev: Some("07263d193d621c4b2b0ce8b4d54af58f6957d97d".to_string()),
+        });
 
-        add_to_config(&dependency, true, target_config.to_str().unwrap(), true).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -1308,14 +1360,14 @@ dep1 = { version = "1.0.0", git = "git@github.com:foundry-rs/forge-std.git" }
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Git(GitDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "git@github.com:foundry-rs/forge-std.git".to_string(),
-            hash: "07263d193d621c4b2b0ce8b4d54af58f6957d97d".to_string(),
-        };
+            git: "git@github.com:foundry-rs/forge-std.git".to_string(),
+            rev: Some("07263d193d621c4b2b0ce8b4d54af58f6957d97d".to_string()),
+        });
 
-        add_to_config(&dependency, true, target_config.to_str().unwrap(), true).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -1362,14 +1414,14 @@ dep1 = { version = "1.0.0", git = "git@github.com:foundry-rs/forge-std.git", rev
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "dep1".to_string(),
             version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
+            url: Some("http://custom_url.com/custom.zip".to_string()),
+            checksum: None,
+        });
 
-        add_to_config(&dependency, true, target_config.to_str().unwrap(), false).unwrap();
+        add_to_config(&dependency, &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -1413,14 +1465,7 @@ dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
-            name: "dep1".to_string(),
-            version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
-
-        delete_config(&dependency.name, target_config.to_str().unwrap()).unwrap();
+        delete_config("dep1", &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 
@@ -1462,14 +1507,7 @@ dep2 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
 
         write_to_config(&target_config, content);
 
-        let dependency = Dependency {
-            name: "dep1".to_string(),
-            version: "1.0.0".to_string(),
-            url: "http://custom_url.com/custom.zip".to_string(),
-            hash: String::new(),
-        };
-
-        delete_config(&dependency.name, target_config.to_str().unwrap()).unwrap();
+        delete_config("dep1", &target_config).unwrap();
         content = r#"
 # Full reference https://github.com/foundry-rs/foundry/tree/master/crates/config
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2114,8 +2114,7 @@ remappings_generate = true
             target = format!("soldeer{}.toml", s);
         }
 
-        let path = get_current_working_dir().join("test").join(target);
-        path
+        get_current_working_dir().join("test").join(target)
     }
 
     #[allow(unused)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,22 @@ impl Dependency {
             ),
         }
     }
+
+    pub fn as_http(&self) -> Option<&HttpDependency> {
+        if let Self::Http(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_git(&self) -> Option<&GitDependency> {
+        if let Self::Git(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 impl core::fmt::Display for Dependency {

--- a/src/config.rs
+++ b/src/config.rs
@@ -803,8 +803,9 @@ libs = ["dependencies"]
                 assert_eq!(
                     err,
                     ConfigError {
-                        cause: "Could not get the config correctly from the config file"
-                            .to_string(),
+                        cause:
+                            "Could not retrieve URL for dependency @gearbox-protocol-periphery-v3"
+                                .to_string(),
                     }
                 )
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -432,13 +432,9 @@ fn parse_dependency(name: impl Into<String>, value: &Item) -> Result<Dependency>
             return Err(ConfigError::EmptyVersion(name));
         }
         // this function does not retrieve the url
-        return Ok(HttpDependency {
-            name,
-            version: version.to_string(),
-            url: None,
-            checksum: None,
-        }
-        .into());
+        return Ok(
+            HttpDependency { name, version: version.to_string(), url: None, checksum: None }.into()
+        );
     }
 
     // we should have a table or inline table

--- a/src/config.rs
+++ b/src/config.rs
@@ -349,6 +349,11 @@ pub fn remove_forge_lib() -> Result<(), ConfigError> {
 fn parse_dependency(name: impl Into<String>, value: &Item) -> Result<Dependency, ConfigError> {
     let name: String = name.into();
     if let Some(version) = value.as_str() {
+        if version.is_empty() {
+            return Err(ConfigError {
+                cause: format!("Field `version` for dependency {name} is empty"),
+            });
+        }
         // this function does not retrieve the url
         return Ok(Dependency::Http(HttpDependency {
             name,
@@ -724,7 +729,7 @@ libs = ["dependencies"]
                     err,
                     ConfigError {
                         cause:
-                            "Could not retrieve URL for dependency @gearbox-protocol-periphery-v3"
+                            "Field `version` for dependency @gearbox-protocol-periphery-v3 is empty"
                                 .to_string(),
                     }
                 )

--- a/src/config.rs
+++ b/src/config.rs
@@ -287,12 +287,12 @@ pub async fn remappings() -> Result<()> {
     });
 
     if new_remappings.is_empty() {
-        remove_empty_lines("remappings.txt");
+        //remove_empty_lines("remappings.txt");
         return Ok(());
     }
 
     fs::write("remappings.txt", new_remappings)?;
-    remove_empty_lines("remappings.txt");
+    remove_empty_lines("remappings.txt").map_err(ConfigError::RemappingsError)?;
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2027,6 +2027,7 @@ remappings_generate = true
     }
 
     #[tokio::test]
+    #[serial]
     async fn generate_remappings_regenerate() -> Result<()> {
         let mut content = r#"
 [profile.default]
@@ -2041,6 +2042,7 @@ remappings_regenerate = true
 "#;
 
         let target_config = define_config(true);
+        env::set_var("config_file", target_config.to_string_lossy().to_string());
 
         write_to_config(&target_config, content);
 
@@ -2113,7 +2115,6 @@ remappings_generate = true
         }
 
         let path = get_current_working_dir().join("test").join(target);
-        env::set_var("config_file", path.to_string_lossy().to_string());
         path
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use std::{
     io::{self, Write},
     path::{Path, PathBuf},
 };
-use toml_edit::{value, Array, DocumentMut, InlineTable, Item, Table};
+use toml_edit::{value, DocumentMut, InlineTable, Item, Table};
 use yansi::Paint as _;
 
 pub type Result<T> = std::result::Result<T, ConfigError>;
@@ -32,7 +32,7 @@ pub struct SoldeerConfig {
     pub reg_remappings: bool,
     pub remappings_version: bool,
     pub remappings_prefix: String,
-    pub remappings_type: RemappingsLocation,
+    pub remappings_loc: RemappingsLocation,
 }
 
 impl Default for SoldeerConfig {
@@ -42,7 +42,7 @@ impl Default for SoldeerConfig {
             reg_remappings: false,
             remappings_version: false,
             remappings_prefix: String::new(),
-            remappings_type: Default::default(),
+            remappings_loc: Default::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use toml_edit::{value, DocumentMut, InlineTable, Item, Table};
-use yansi::Paint;
+use yansi::Paint as _;
 
 pub type Result<T> = std::result::Result<T, ConfigError>;
 
@@ -215,11 +215,12 @@ pub fn get_config_path() -> Result<PathBuf> {
 pub fn add_to_config(dependency: &Dependency, config_path: impl AsRef<Path>) -> Result<()> {
     println!(
         "{}",
-        Paint::green(&format!(
+        format!(
             "Adding dependency {}-{} to the config file",
             dependency.name(),
             dependency.version()
-        ))
+        )
+        .green()
     );
 
     let contents = read_file_to_string(&config_path);
@@ -273,10 +274,8 @@ pub async fn remappings() -> Result<()> {
         if index.is_none() {
             println!(
                 "{}",
-                Paint::green(&format!(
-                    "Added a new dependency to remappings {}",
-                    &dependency_name_formatted
-                ))
+                format!("Added a new dependency to remappings {}", &dependency_name_formatted)
+                    .green()
             );
             new_remappings.push_str(&format!(
                 "\n{}=dependencies/{}-{}",
@@ -300,7 +299,7 @@ pub async fn remappings() -> Result<()> {
 pub fn delete_config(dependency_name: &str, path: impl AsRef<Path>) -> Result<Dependency> {
     println!(
         "{}",
-        Paint::green(&format!("Removing the dependency {dependency_name} from the config file"))
+        format!("Removing the dependency {dependency_name} from the config file").green()
     );
 
     let contents = read_file_to_string(&path);

--- a/src/config.rs
+++ b/src/config.rs
@@ -475,7 +475,6 @@ mod tests {
     use rand::{distributions::Alphanumeric, Rng};
     use serial_test::serial;
     use std::{
-        env,
         fs::{
             remove_file, {self},
         },
@@ -1521,6 +1520,7 @@ dep1 = { version = "1.0.0", url = "http://custom_url.com/custom.zip" }
         get_current_working_dir().join("test").join(target)
     }
 
+    #[allow(unused)]
     fn get_return_data() -> String {
         r#"
         {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,21 +28,21 @@ pub enum RemappingsLocation {
 /// The Soldeer config options
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct SoldeerConfig {
-    pub generate_remappings: bool,
-    pub reg_remappings: bool,
+    pub remappings_generate: bool,
+    pub remappings_regenerate: bool,
     pub remappings_version: bool,
     pub remappings_prefix: String,
-    pub remappings_loc: RemappingsLocation,
+    pub remappings_location: RemappingsLocation,
 }
 
 impl Default for SoldeerConfig {
     fn default() -> Self {
         SoldeerConfig {
-            generate_remappings: true,
-            reg_remappings: false,
+            remappings_generate: true,
+            remappings_regenerate: false,
             remappings_version: false,
             remappings_prefix: String::new(),
-            remappings_loc: Default::default(),
+            remappings_location: Default::default(),
         }
     }
 }
@@ -313,7 +313,7 @@ fn generate_remappings(
     existing_remappings: Vec<(&str, &str)>,
 ) -> Result<Vec<String>> {
     let mut new_remappings = Vec::new();
-    if soldeer_config.reg_remappings {
+    if soldeer_config.remappings_regenerate {
         let dependencies = read_config_deps(None)?;
 
         dependencies.iter().for_each(|dependency| {
@@ -354,7 +354,7 @@ pub async fn remappings_txt(
     soldeer_config: &SoldeerConfig,
 ) -> Result<()> {
     let remappings_path = get_current_working_dir().join("remappings.txt");
-    if soldeer_config.reg_remappings {
+    if soldeer_config.remappings_regenerate {
         remove_file(&remappings_path).map_err(ConfigError::RemappingsError)?;
     }
     if !remappings_path.exists() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2085,7 +2085,10 @@ remappings_regenerate = true
 "#;
 
         let target_config = define_config(true);
-        env::set_var("config_file", target_config.to_string_lossy().to_string());
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("config_file", target_config.to_string_lossy().to_string());
+        }
 
         write_to_config(&target_config, content);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use std::{
     io::{self, Write},
     path::{Path, PathBuf},
 };
-use toml_edit::{value, DocumentMut, Item, Table};
+use toml_edit::{value, DocumentMut, InlineTable, Item, Table};
 use yansi::Paint;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -65,10 +65,18 @@ impl Dependency {
                 dep.name.clone(),
                 match &dep.url {
                     Some(url) => {
-                        let mut table = Table::new();
-                        table["version"] = value(&dep.version);
-                        table["url"] = value(url);
-                        Item::Table(table)
+                        let mut table = InlineTable::new();
+                        table.insert(
+                            "version",
+                            value(&dep.version)
+                                .into_value()
+                                .expect("version should be a valid toml value"),
+                        );
+                        table.insert(
+                            "url",
+                            value(url).into_value().expect("url should be a valid toml value"),
+                        );
+                        value(table)
                     }
                     None => value(&dep.version),
                 },
@@ -77,17 +85,41 @@ impl Dependency {
                 dep.name.clone(),
                 match &dep.rev {
                     Some(rev) => {
-                        let mut table = Table::new();
-                        table["version"] = value(&dep.version);
-                        table["git"] = value(&dep.git);
-                        table["rev"] = value(rev);
-                        Item::Table(table)
+                        let mut table = InlineTable::new();
+                        table.insert(
+                            "version",
+                            value(&dep.version)
+                                .into_value()
+                                .expect("version should be a valid toml value"),
+                        );
+                        table.insert(
+                            "git",
+                            value(&dep.git)
+                                .into_value()
+                                .expect("git URL should be a valid toml value"),
+                        );
+                        table.insert(
+                            "rev",
+                            value(rev).into_value().expect("rev should be a valid toml value"),
+                        );
+                        value(table)
                     }
                     None => {
-                        let mut table = Table::new();
-                        table["version"] = value(&dep.version);
-                        table["git"] = value(&dep.git);
-                        Item::Table(table)
+                        let mut table = InlineTable::new();
+                        table.insert(
+                            "version",
+                            value(&dep.version)
+                                .into_value()
+                                .expect("version should be a valid toml value"),
+                        );
+                        table.insert(
+                            "git",
+                            value(&dep.git)
+                                .into_value()
+                                .expect("git URL should be a valid toml value"),
+                        );
+
+                        value(table)
                     }
                 },
             ),
@@ -1192,10 +1224,10 @@ test = "test"
 libs = ["dependencies"]
 gas_reports = ['*']
 
-# we don't have [dependencies] declared
-
 [dependencies]
 dep1 = "1.0.0"
+
+# we don't have [dependencies] declared
 "#;
 
         assert_eq!(read_file_to_string(&target_config), content);

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use reqwest::IntoUrl;
 use std::{
-    ffi::{OsStr, OsString},
     fs::{self, remove_dir_all},
     io::Cursor,
     path::{Path, PathBuf},
@@ -139,6 +138,7 @@ async fn download_via_git(
 ) -> Result<String, DownloadError> {
     let target_dir = &format!("{}-{}", dependency.name, dependency.version);
     let path = dependency_directory.join(target_dir);
+    let path_str = path.to_string_lossy().to_string();
     if path.exists() {
         let _ = remove_dir_all(&path);
     }
@@ -149,7 +149,7 @@ async fn download_via_git(
     let mut git_get_commit = Command::new("git");
 
     let result = git_clone
-        .args([OsStr::new("clone"), http_url.as_os_str(), path.as_os_str()])
+        .args(["clone", &http_url, &path_str])
         .env("GIT_TERMINAL_PROMPT", "0")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -291,15 +291,15 @@ pub fn delete_dependency_files(dependency: &Dependency) -> Result<(), Dependency
     Ok(())
 }
 
-fn transform_git_to_http(url: &str) -> OsString {
+fn transform_git_to_http(url: &str) -> String {
     if let Some(stripped) = url.strip_prefix("git@github.com:") {
         let repo_path = stripped;
-        format!("https://github.com/{}", repo_path).into()
+        format!("https://github.com/{}", repo_path)
     } else if let Some(stripped) = url.strip_prefix("git@gitlab.com:") {
         let repo_path = stripped;
-        format!("https://gitlab.com/{}", repo_path).into()
+        format!("https://gitlab.com/{}", repo_path)
     } else {
-        url.to_string().into()
+        url.to_string()
     }
 }
 

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -25,7 +25,7 @@ pub async fn download_dependencies(
     // clean dependencies folder if flag is true
     if clean {
         // creates the directory
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     // create the dependency directory if it doesn't exist
@@ -120,10 +120,10 @@ pub fn unzip_dependency(dependency: &HttpDependency) -> Result<()> {
     Ok(())
 }
 
-pub async fn clean_dependency_directory() {
-    if tokio_fs::metadata(DEPENDENCY_DIR.clone()).await.is_ok() {
-        tokio_fs::remove_dir_all(DEPENDENCY_DIR.clone()).await.unwrap();
-        tokio_fs::create_dir(DEPENDENCY_DIR.clone()).await.unwrap();
+pub fn clean_dependency_directory() {
+    if fs::metadata(DEPENDENCY_DIR.clone()).is_ok() {
+        fs::remove_dir_all(DEPENDENCY_DIR.clone()).unwrap();
+        fs::create_dir(DEPENDENCY_DIR.clone()).unwrap();
     }
 }
 
@@ -293,13 +293,13 @@ mod tests {
         assert!(path_zip.exists());
         assert!(results.len() == 1);
         assert!(!results[0].hash.is_empty());
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
     #[serial]
     async fn download_dependencies_git_one_success() {
-        clean_dependency_directory().await;
+        clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
         let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
@@ -315,13 +315,13 @@ mod tests {
         assert!(path_dir.join("src").join("auth").join("Owned.sol").exists());
         assert!(results.len() == 1);
         assert!(!results[0].hash.is_empty());
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
     #[serial]
     async fn download_dependencies_gitlab_giturl_one_success() {
-        clean_dependency_directory().await;
+        clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
         let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
@@ -337,13 +337,13 @@ mod tests {
         assert!(path_dir.join("JustATest3.md").exists());
         assert!(results.len() == 1);
         assert_eq!(results[0].hash, "22868f426bd4dd0e682b5ec5f9bd55507664240c"); // this is the last commit, hash == commit
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
     #[serial]
     async fn download_dependency_gitlab_giturl_with_a_specific_revision() {
-        clean_dependency_directory().await;
+        clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
         let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
@@ -366,13 +366,13 @@ mod tests {
             .join("JustATest2.md");
         assert!(test_right_revision.exists());
 
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
     #[serial]
     async fn download_dependencies_gitlab_httpurl_one_success() {
-        clean_dependency_directory().await;
+        clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
         let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
@@ -388,7 +388,7 @@ mod tests {
         assert!(path_dir.join("README.md").exists());
         assert!(results.len() == 1);
         assert_eq!(results[0].hash, "22868f426bd4dd0e682b5ec5f9bd55507664240c"); // this is the last commit, hash == commit
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -428,7 +428,7 @@ mod tests {
         assert!(results.len() == 2);
         assert!(!results[0].hash.is_empty());
         assert!(!results[1].hash.is_empty());
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -480,7 +480,7 @@ mod tests {
         assert!(results.len() == 2);
         assert!(!results[0].hash.is_empty());
         assert!(!results[1].hash.is_empty());
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -519,7 +519,7 @@ mod tests {
         assert!(size_of_two > size_of_one);
         assert!(results.len() == 1);
         assert!(!results[0].hash.is_empty());
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -560,7 +560,7 @@ mod tests {
         assert!(path_zip.exists());
         assert!(results.len() == 1);
         assert!(!results[0].hash.is_empty());
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -584,7 +584,7 @@ mod tests {
                 assert_eq!(err.to_string(), "error downloading dependency: HTTP status client error (404 Not Found) for url (https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~.zip)");
             }
         }
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -610,7 +610,7 @@ mod tests {
                 assert!(err.to_string().contains("Cloning into"));
             }
         }
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -632,11 +632,11 @@ mod tests {
                 assert!(metadata(&path).unwrap().len() > 0);
             }
             Err(_) => {
-                clean_dependency_directory().await;
+                clean_dependency_directory();
                 assert_eq!("Error", "");
             }
         }
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -656,14 +656,14 @@ mod tests {
         download_dependencies(&dependencies, false).await.unwrap();
         match unzip_dependencies(&dependencies) {
             Ok(_) => {
-                clean_dependency_directory().await;
+                clean_dependency_directory();
                 assert_eq!("Wrong State", "");
             }
             Err(err) => {
                 assert!(matches!(err, DownloadError::UnzipError(_)));
             }
         }
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[tokio::test]
@@ -685,7 +685,7 @@ mod tests {
             .join("ERC20")
             .join("ERC20.sol")
             .exists());
-        clean_dependency_directory().await;
+        clean_dependency_directory();
     }
 
     #[test]

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -47,6 +47,7 @@ pub fn unzip_dependencies(dependencies: &[Dependency]) -> Result<(), UnzippingEr
     Ok(())
 }
 
+#[derive(Debug, Clone)]
 pub struct DownloadResult {
     pub hash: String,
     pub url: String,
@@ -422,11 +423,11 @@ mod tests {
     async fn download_dependencies_gitlab_httpurl_one_success() {
         clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency = Dependency::Http(HttpDependency {
+        let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: Some("https://gitlab.com/mario4582928/Mario.git".to_string()),
-            checksum: None,
+            git: "https://gitlab.com/mario4582928/Mario.git".to_string(),
+            rev: None,
         });
         dependencies.push(dependency.clone());
         let results = download_dependencies(&dependencies, false).await.unwrap();

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -245,7 +245,7 @@ mod tests {
     use super::*;
     use crate::{
         janitor::healthcheck_dependency,
-        utils::{get_dependency_type, DependencyType},
+        utils::{get_url_type, UrlType},
     };
     use serial_test::serial;
     use std::{fs::metadata, path::Path};
@@ -665,27 +665,19 @@ mod tests {
     #[test]
     fn get_download_tunnel_http() {
         assert_eq!(
-            get_dependency_type(
-                "https://github.com/foundry-rs/forge-std/archive/refs/tags/v1.9.1.zip"
-            ),
-            DependencyType::Http
+            get_url_type("https://github.com/foundry-rs/forge-std/archive/refs/tags/v1.9.1.zip"),
+            UrlType::Http
         );
     }
 
     #[test]
     fn get_download_tunnel_git_giturl() {
-        assert_eq!(
-            get_dependency_type("git@github.com:foundry-rs/forge-std.git"),
-            DependencyType::Git
-        );
+        assert_eq!(get_url_type("git@github.com:foundry-rs/forge-std.git"), UrlType::Git);
     }
 
     #[test]
     fn get_download_tunnel_git_githttp() {
-        assert_eq!(
-            get_dependency_type("https://github.com/foundry-rs/forge-std.git"),
-            DependencyType::Git
-        );
+        assert_eq!(get_url_type("https://github.com/foundry-rs/forge-std.git"), UrlType::Git);
     }
 
     #[test]

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -1,10 +1,11 @@
 use crate::{
-    config::Dependency,
+    config::{Dependency, GitDependency, HttpDependency},
     errors::{DependencyError, DownloadError, UnzippingError},
-    utils::{get_download_tunnel, read_file, sha256_digest},
+    utils::{read_file, sha256_digest},
     DEPENDENCY_DIR,
 };
-use futures::StreamExt;
+use futures::StreamExt as _;
+use reqwest::IntoUrl;
 use std::{
     error::Error,
     fs,
@@ -27,7 +28,7 @@ pub async fn download_dependencies(
     }
     // downloading dependencies to dependencies folder
     let hashes: Vec<String> = futures::future::join_all(
-        dependencies.iter().map(|dep| async { download_dependency(&dep.clone()).await }),
+        dependencies.iter().map(|dep| async { download_dependency(dep).await }),
     )
     .await
     .into_iter()
@@ -38,17 +39,13 @@ pub async fn download_dependencies(
 
 // un-zip-ing dependencies to dependencies folder
 pub fn unzip_dependencies(dependencies: &[Dependency]) -> Result<(), UnzippingError> {
-    for dependency in dependencies.iter() {
-        let via_http = get_download_tunnel(&dependency.url) != "git";
-        if via_http {
-            match unzip_dependency(&dependency.name, &dependency.version) {
-                Ok(_) => {}
-                Err(err) => {
-                    return Err(err);
-                }
-            }
-        }
-    }
+    dependencies
+        .iter()
+        .filter_map(|d| match d {
+            Dependency::Http(dep) => Some(dep),
+            _ => None,
+        })
+        .try_for_each(|d| unzip_dependency(&d.name, &d.version))?;
     Ok(())
 }
 
@@ -58,49 +55,47 @@ pub async fn download_dependency(dependency: &Dependency) -> Result<String, Down
         fs::create_dir(&dependency_directory).unwrap();
     }
 
-    let tunnel = get_download_tunnel(&dependency.url);
-    let hash: String;
-    if tunnel == "http" {
-        match download_via_http(dependency, &dependency_directory).await {
-            Ok(_) => {}
-            Err(err) => {
+    let hash = match dependency {
+        Dependency::Http(dep) => {
+            let Some(url) = &dep.url else {
                 return Err(DownloadError {
-                    name: dependency.name.to_string(),
-                    version: dependency.version.to_string(),
-                    cause: err.cause,
+                    name: dep.name.to_string(),
+                    version: dep.version.to_string(),
+                    cause: "Dependency URL is missing".to_string(),
                 });
-            }
+            };
+            download_via_http(url, dep, &dependency_directory).await.map_err(|err| {
+                DownloadError {
+                    name: dep.name.to_string(),
+                    version: dep.version.to_string(),
+                    cause: err.cause,
+                }
+            })?;
+            sha256_digest(&dep.name, &dep.version)
         }
-        hash = sha256_digest(&dependency.name, &dependency.version);
-    } else if tunnel == "git" {
-        hash = match download_via_git(dependency, &dependency_directory).await {
-            Ok(h) => h,
-            Err(err) => {
-                return Err(DownloadError {
-                    name: dependency.name.to_string(),
-                    version: dependency.version.to_string(),
-                    cause: err.cause,
-                });
-            }
-        };
-    } else {
-        return Err(DownloadError {
-            name: dependency.name.to_string(),
-            version: dependency.version.to_string(),
-            cause: "Download tunnel unknown".to_string(),
-        });
-    }
+        Dependency::Git(dep) => {
+            download_via_git(dep, &dependency_directory).await.map_err(|err| DownloadError {
+                name: dep.name.to_string(),
+                version: dep.version.to_string(),
+                cause: err.cause,
+            })?
+        }
+    };
     println!(
         "{}",
-        Paint::green(&format!("Dependency {}-{} downloaded!", dependency.name, dependency.version))
+        Paint::green(&format!(
+            "Dependency {}-{} downloaded!",
+            dependency.name(),
+            dependency.version()
+        ))
     );
 
     Ok(hash)
 }
 
 pub fn unzip_dependency(
-    dependency_name: &String,
-    dependency_version: &String,
+    dependency_name: &str,
+    dependency_version: &str,
 ) -> Result<(), UnzippingError> {
     let file_name = format!("{}-{}.zip", dependency_name, dependency_version);
     let target_name = format!("{}-{}/", dependency_name, dependency_version);
@@ -135,7 +130,7 @@ pub fn clean_dependency_directory() {
 }
 
 async fn download_via_git(
-    dependency: &Dependency,
+    dependency: &GitDependency,
     dependency_directory: &Path,
 ) -> Result<String, DownloadError> {
     let target_dir = &format!("{}-{}", dependency.name, dependency.version);
@@ -145,7 +140,7 @@ async fn download_via_git(
         let _ = remove_dir_all(&path);
     }
 
-    let http_url: String = transform_git_to_http(&dependency.url);
+    let http_url: String = transform_git_to_http(&dependency.git);
     let mut git_clone = Command::new("git");
     let mut git_checkout = Command::new("git");
     let mut git_get_commit = Command::new("git");
@@ -157,162 +152,139 @@ async fn download_via_git(
         .stderr(Stdio::piped());
 
     let status = result.status().unwrap();
-
-    let mut success = status.success();
     let out = result.output().unwrap();
-    let mut message = String::new();
-    let hash: String;
-    if !success {
-        message = format!(
+
+    let mut err = DownloadError {
+        name: dependency.name.to_string(),
+        version: dependency.version.to_string(),
+        cause: format!(
+            "Dependency {}~{} could not be downloaded via git.\nCause: ",
+            dependency.name.clone(),
+            dependency.version.clone(),
+        ),
+    };
+
+    if !status.success() {
+        let _ = remove_dir_all(&path);
+        err.cause.push_str(&format!(
             "Could not clone the repository: {}",
             str::from_utf8(&out.stderr).unwrap().trim()
-        );
-    }
-    if !dependency.hash.is_empty() && success {
-        let result = git_get_commit
-            .args([
-                format!("--work-tree={}", dependency_path),
-                format!("--git-dir={}", path.join(".git").as_os_str().to_str().unwrap()),
-                "checkout".to_string(),
-                dependency.hash.clone(),
-            ])
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        hash = dependency.hash.clone();
-
-        let out = result.output().unwrap();
-        let status = result.status().unwrap();
-        success = status.success();
-
-        if !success {
-            message = format!(
-                "Could not change the revision: {}",
-                str::from_utf8(&out.stderr).unwrap().trim()
-            );
-        }
-    } else if success {
-        let result = git_checkout
-            .args([
-                format!("--work-tree={}", dependency_path),
-                format!("--git-dir={}", path.join(".git").as_os_str().to_str().unwrap()),
-                "rev-parse".to_string(),
-                "--verify".to_string(),
-                "HEAD".to_string(),
-            ])
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let out = result.output().unwrap();
-        let status = result.status().unwrap();
-        success = status.success();
-        if !success {
-            message = format!(
-                "Could not get the revision hash: {}",
-                str::from_utf8(&out.stderr).unwrap().trim()
-            );
-        }
-
-        hash = str::from_utf8(&out.stdout).unwrap().trim().to_string();
-
-        // check the commit integrity
-        if !hash.is_empty() && hash.len() != 40 {
-            message = "Could not get the revision hash, invalid hash".to_string();
-        }
-    } else {
-        // just abort and return empty hash
-        hash = String::new();
+        ));
+        return Err(err);
     }
 
-    if success {
-        println!(
-            "{}",
-            Paint::green(&format!(
-                "Successfully downloaded {}~{} the dependency via git",
-                dependency.name.clone(),
-                dependency.version.clone(),
-            ))
-        );
-    } else {
-        let _ = remove_dir_all(&path);
-        return Err(DownloadError {
-            name: dependency.name.to_string(),
-            version: dependency.version.to_string(),
-            cause: format!(
-                "Dependency {}~{} could not be downloaded via git.\nCause: {}",
-                dependency.name.clone(),
-                dependency.version.clone(),
-                message
-            ),
-        });
-    }
+    let rev = match dependency.rev.clone() {
+        Some(rev) => {
+            let result = git_get_commit
+                .args([
+                    format!("--work-tree={}", dependency_path),
+                    format!("--git-dir={}", path.join(".git").to_string_lossy()),
+                    "checkout".to_string(),
+                    rev.to_string(),
+                ])
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
 
-    Ok(hash.to_string())
+            let out = result.output().unwrap();
+            let status = result.status().unwrap();
+
+            if !status.success() {
+                let _ = remove_dir_all(&path);
+                err.cause.push_str(&format!(
+                    "Could not checkout the rev: {}",
+                    str::from_utf8(&out.stderr).unwrap().trim()
+                ));
+                return Err(err);
+            }
+            rev
+        }
+        None => {
+            let result = git_checkout
+                .args([
+                    format!("--work-tree={}", dependency_path),
+                    format!("--git-dir={}", path.join(".git").to_string_lossy()),
+                    "rev-parse".to_string(),
+                    "--verify".to_string(),
+                    "HEAD".to_string(),
+                ])
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+
+            let out = result.output().unwrap();
+            let status = result.status().unwrap();
+            if !status.success() {
+                let _ = remove_dir_all(&path);
+                err.cause.push_str(&format!(
+                    "Could not get the revision hash: {}",
+                    str::from_utf8(&out.stderr).unwrap().trim()
+                ));
+                return Err(err);
+            }
+
+            let hash = str::from_utf8(&out.stdout).unwrap().trim().to_string();
+            // check the commit hash
+            if !hash.is_empty() && hash.len() != 40 {
+                let _ = remove_dir_all(&path);
+                err.cause.push_str("Could not get the revision hash, invalid hash");
+                return Err(err);
+            }
+            hash
+        }
+    };
+    println!(
+        "{}",
+        Paint::green(&format!(
+            "Successfully downloaded {}~{} the dependency via git",
+            dependency.name.clone(),
+            dependency.version.clone(),
+        ))
+    );
+    Ok(rev)
 }
 
 async fn download_via_http(
-    dependency: &Dependency,
+    url: impl IntoUrl,
+    dependency: &HttpDependency,
     dependency_directory: &Path,
 ) -> Result<(), DownloadError> {
     let zip_to_download = &format!("{}-{}.zip", dependency.name, dependency.version);
-    let mut stream = match reqwest::get(&dependency.url).await {
-        Ok(res) => {
-            if res.status() != 200 {
-                return Err(DownloadError {
-                    name: dependency.name.clone().to_string(),
-                    version: dependency.url.clone().to_string(),
-                    cause: format!(
-                        "Dependency {}~{} could not be downloaded via http.\nStatus: {}",
-                        dependency.name.clone(),
-                        dependency.version.clone(),
-                        res.status()
-                    ),
-                });
-            }
-            res.bytes_stream()
-        }
-        Err(err) => {
-            return Err(DownloadError {
-                name: dependency.name.clone().to_string(),
-                version: dependency.url.clone().to_string(),
-                cause: format!("Unknown error: {:?}", err.source().unwrap()),
-            });
-        }
-    };
+    let mut resp = reqwest::get(url).await.map_err(|e| DownloadError {
+        name: dependency.name.clone(),
+        version: dependency.version.clone(),
+        cause: format!("Error downloading zip file: {e:?}"),
+    })?;
 
-    let mut file = File::create(&dependency_directory.join(zip_to_download)).await.unwrap();
-
-    while let Some(chunk_result) = stream.next().await {
-        match file.write_all(&chunk_result.unwrap()).await {
-            Ok(_) => {}
-            Err(err) => {
-                return Err(DownloadError {
-                    name: dependency.name.to_string(),
-                    version: dependency.version.to_string(),
-                    cause: format!("Unknown error: {:?}", err.source().unwrap()),
-                });
+    let mut file =
+        File::create(&dependency_directory.join(zip_to_download)).await.map_err(|e| {
+            DownloadError {
+                name: dependency.name.clone(),
+                version: dependency.version.clone(),
+                cause: format!("Unable to create zip file: {e:?}"),
             }
-        }
+        })?;
+
+    while let Some(mut chunk) = resp.chunk().await.map_err(|e| DownloadError {
+        name: dependency.name.clone(),
+        version: dependency.version.clone(),
+        cause: format!("Unable to download chunk of zip file: {e:?}"),
+    })? {
+        file.write_all_buf(&mut chunk).await.map_err(|e| DownloadError {
+            name: dependency.name.clone(),
+            version: dependency.version.clone(),
+            cause: format!("Unable to write to zip file: {e:?}"),
+        })?;
     }
-
-    match file.flush().await {
-        Ok(_) => {}
-        Err(err) => {
-            return Err(DownloadError {
-                name: dependency.name.to_string(),
-                version: dependency.url.to_string(),
-                cause: format!("Unknown error: {:?}", err.source().unwrap()),
-            });
-        }
-    };
     Ok(())
 }
 
 pub fn delete_dependency_files(dependency: &Dependency) -> Result<(), DependencyError> {
-    let _ =
-        remove_dir_all(DEPENDENCY_DIR.join(format!("{}-{}", dependency.name, dependency.version)));
+    let _ = remove_dir_all(DEPENDENCY_DIR.join(format!(
+        "{}-{}",
+        dependency.name(),
+        dependency.version()
+    )));
     Ok(())
 }
 
@@ -332,7 +304,10 @@ fn transform_git_to_http(url: &str) -> String {
 #[allow(clippy::vec_init_then_push)]
 mod tests {
     use super::*;
-    use crate::janitor::healthcheck_dependency;
+    use crate::{
+        janitor::healthcheck_dependency,
+        utils::{get_dependency_type, DependencyType},
+    };
     use serial_test::serial;
     use std::{fs::metadata, path::Path};
 
@@ -340,16 +315,16 @@ mod tests {
     #[serial]
     async fn download_dependencies_http_one_success() {
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
-            hash: String::new()
-        };
+            url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
+            checksum: None
+        });
         dependencies.push(dependency.clone());
         let hashes = download_dependencies(&dependencies, false).await.unwrap();
         let path_zip =
-            DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name, &dependency.version));
+            DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name(), &dependency.version()));
         assert!(path_zip.exists());
         assert!(hashes.len() == 1);
         assert!(!hashes[0].is_empty());
@@ -361,15 +336,16 @@ mod tests {
     async fn download_dependencies_git_one_success() {
         clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency = Dependency {
+        let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "git@github.com:transmissions11/solmate.git".to_string(),
-            hash: String::new(),
-        };
+            git: "git@github.com:transmissions11/solmate.git".to_string(),
+            rev: None,
+        });
         dependencies.push(dependency.clone());
         let hashes = download_dependencies(&dependencies, false).await.unwrap();
-        let path_dir = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
+        let path_dir =
+            DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         assert!(path_dir.exists());
         assert!(path_dir.join("src").join("auth").join("Owned.sol").exists());
         assert!(hashes.len() == 1);
@@ -382,15 +358,16 @@ mod tests {
     async fn download_dependencies_gitlab_giturl_one_success() {
         clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency = Dependency {
+        let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "git@gitlab.com:mario4582928/Mario.git".to_string(),
-            hash: String::new(),
-        };
+            git: "git@gitlab.com:mario4582928/Mario.git".to_string(),
+            rev: None,
+        });
         dependencies.push(dependency.clone());
         let hashes = download_dependencies(&dependencies, false).await.unwrap();
-        let path_dir = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
+        let path_dir =
+            DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         assert!(path_dir.exists());
         assert!(path_dir.join("JustATest3.md").exists());
         assert!(hashes.len() == 1);
@@ -403,15 +380,16 @@ mod tests {
     async fn download_dependency_gitlab_giturl_with_a_specific_revision() {
         clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency = Dependency {
+        let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "git@gitlab.com:mario4582928/Mario.git".to_string(),
-            hash: "7a0663eaf7488732f39550be655bad6694974cb3".to_string(),
-        };
+            git: "git@gitlab.com:mario4582928/Mario.git".to_string(),
+            rev: Some("7a0663eaf7488732f39550be655bad6694974cb3".to_string()),
+        });
         dependencies.push(dependency.clone());
         let hashes = download_dependencies(&dependencies, false).await.unwrap();
-        let path_dir = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
+        let path_dir =
+            DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         assert!(path_dir.exists());
         assert!(path_dir.join("README.md").exists());
         assert!(hashes.len() == 1);
@@ -419,7 +397,7 @@ mod tests {
 
         // at this revision, this file should exists
         let test_right_revision = DEPENDENCY_DIR
-            .join(format!("{}-{}", &dependency.name, &dependency.version))
+            .join(format!("{}-{}", &dependency.name(), &dependency.version()))
             .join("JustATest2.md");
         assert!(test_right_revision.exists());
 
@@ -431,15 +409,16 @@ mod tests {
     async fn download_dependencies_gitlab_httpurl_one_success() {
         clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "https://gitlab.com/mario4582928/Mario.git".to_string(),
-            hash: String::new(),
-        };
+            url: Some("https://gitlab.com/mario4582928/Mario.git".to_string()),
+            checksum: None,
+        });
         dependencies.push(dependency.clone());
         let hashes = download_dependencies(&dependencies, false).await.unwrap();
-        let path_dir = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
+        let path_dir =
+            DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         assert!(path_dir.exists());
         assert!(path_dir.join("README.md").exists());
         assert!(hashes.len() == 1);
@@ -451,29 +430,35 @@ mod tests {
     #[serial]
     async fn download_dependencies_http_two_success() {
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let  dependency_one = Dependency {
+        let  dependency_one = Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
-            hash: String::new()
-        };
+            url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
+            checksum: None
+        });
         dependencies.push(dependency_one.clone());
 
-        let dependency_two = Dependency {
+        let dependency_two = Dependency::Http(HttpDependency {
             name: "@uniswap-v2-core".to_string(),
             version: "1.0.0-beta.4".to_string(),
-            url: "https://soldeer-revisions.s3.amazonaws.com/@uniswap-v2-core/1_0_0-beta_4_22-01-2024_13:18:27_v2-core.zip".to_string(),
-            hash: String::new()
-        };
+            url: Some("https://soldeer-revisions.s3.amazonaws.com/@uniswap-v2-core/1_0_0-beta_4_22-01-2024_13:18:27_v2-core.zip".to_string()),
+            checksum: None
+        });
 
         dependencies.push(dependency_two.clone());
         let hashes = download_dependencies(&dependencies, false).await.unwrap();
-        let mut path_zip = DEPENDENCY_DIR
-            .join(format!("{}-{}.zip", &dependency_one.name, &dependency_one.version));
+        let mut path_zip = DEPENDENCY_DIR.join(format!(
+            "{}-{}.zip",
+            &dependency_one.name(),
+            &dependency_one.version()
+        ));
         assert!(path_zip.exists());
 
-        path_zip = DEPENDENCY_DIR
-            .join(format!("{}-{}.zip", &dependency_two.name, &dependency_two.version));
+        path_zip = DEPENDENCY_DIR.join(format!(
+            "{}-{}.zip",
+            &dependency_two.name(),
+            &dependency_two.version()
+        ));
         assert!(path_zip.exists());
         assert!(hashes.len() == 2);
         assert!(!hashes[0].is_empty());
@@ -485,34 +470,46 @@ mod tests {
     #[serial]
     async fn download_dependencies_git_two_success() {
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency_one = Dependency {
+        let dependency_one = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "git@github.com:transmissions11/solmate.git".to_string(),
-            hash: String::new(),
-        };
+            git: "git@github.com:transmissions11/solmate.git".to_string(),
+            rev: None,
+        });
         dependencies.push(dependency_one.clone());
 
-        let dependency_two = Dependency {
+        let dependency_two = Dependency::Git(GitDependency {
             name: "@uniswap-v2-core".to_string(),
             version: "1.0.0-beta.4".to_string(),
-            url: "https://gitlab.com/mario4582928/Mario.git".to_string(),
-            hash: String::new(),
-        };
+            git: "https://gitlab.com/mario4582928/Mario.git".to_string(),
+            rev: None,
+        });
 
         dependencies.push(dependency_two.clone());
         let hashes = download_dependencies(&dependencies, false).await.unwrap();
-        let mut path_dir =
-            DEPENDENCY_DIR.join(format!("{}-{}", &dependency_one.name, &dependency_one.version));
-        let mut path_dir_two =
-            DEPENDENCY_DIR.join(format!("{}-{}", &dependency_two.name, &dependency_two.version));
+        let mut path_dir = DEPENDENCY_DIR.join(format!(
+            "{}-{}",
+            &dependency_one.name(),
+            &dependency_one.version()
+        ));
+        let mut path_dir_two = DEPENDENCY_DIR.join(format!(
+            "{}-{}",
+            &dependency_two.name(),
+            &dependency_two.version()
+        ));
         assert!(path_dir.exists());
         assert!(path_dir_two.exists());
 
-        path_dir =
-            DEPENDENCY_DIR.join(format!("{}-{}", &dependency_one.name, &dependency_one.version));
-        path_dir_two =
-            DEPENDENCY_DIR.join(format!("{}-{}", &dependency_two.name, &dependency_two.version));
+        path_dir = DEPENDENCY_DIR.join(format!(
+            "{}-{}",
+            &dependency_one.name(),
+            &dependency_one.version()
+        ));
+        path_dir_two = DEPENDENCY_DIR.join(format!(
+            "{}-{}",
+            &dependency_two.name(),
+            &dependency_two.version()
+        ));
         assert!(path_dir.exists());
         assert!(path_dir_two.exists());
         assert!(hashes.len() == 2);
@@ -525,23 +522,28 @@ mod tests {
     #[serial]
     async fn download_dependency_should_replace_existing_zip() {
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let  dependency_one = Dependency {
+        let dependency_one = Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "download-dep-v1".to_string(),
-            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
-            hash: String::new() };
+            url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
+            checksum: None
+        });
         dependencies.push(dependency_one.clone());
 
         download_dependencies(&dependencies, false).await.unwrap();
-        let path_zip = DEPENDENCY_DIR
-            .join(format!("{}-{}.zip", &dependency_one.name, &dependency_one.version));
+        let path_zip = DEPENDENCY_DIR.join(format!(
+            "{}-{}.zip",
+            &dependency_one.name(),
+            &dependency_one.version()
+        ));
         let size_of_one = fs::metadata(Path::new(&path_zip)).unwrap().len();
 
-        let  dependency_two = Dependency {
+        let dependency_two = Dependency::Http(HttpDependency {
                 name: "@openzeppelin-contracts".to_string(),
                 version: "download-dep-v1".to_string(),
-                url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.4.0.zip".to_string(),
-                hash: String::new()};
+                url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.4.0.zip".to_string()),
+                checksum: None
+            });
 
         dependencies = Vec::new();
         dependencies.push(dependency_two.clone());
@@ -559,31 +561,36 @@ mod tests {
     #[serial]
     async fn download_dependencies_one_with_clean_success() {
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency_old = Dependency {
+        let dependency_old = Dependency::Http(HttpDependency {
             name: "@uniswap-v2-core".to_string(),
             version: "1.0.0-beta.4".to_string(),
-            url: "https://soldeer-revisions.s3.amazonaws.com/@uniswap-v2-core/1_0_0-beta_4_22-01-2024_13:18:27_v2-core.zip".to_string(),
-            hash: String::new()};
+            url: Some("https://soldeer-revisions.s3.amazonaws.com/@uniswap-v2-core/1_0_0-beta_4_22-01-2024_13:18:27_v2-core.zip".to_string()),
+            checksum: None
+        });
 
         dependencies.push(dependency_old.clone());
         download_dependencies(&dependencies, false).await.unwrap();
 
         // making sure the dependency exists so we can check the deletion
-        let path_zip_old = DEPENDENCY_DIR
-            .join(format!("{}-{}.zip", &dependency_old.name, &dependency_old.version));
+        let path_zip_old = DEPENDENCY_DIR.join(format!(
+            "{}-{}.zip",
+            &dependency_old.name(),
+            &dependency_old.version()
+        ));
         assert!(path_zip_old.exists());
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
-            hash: String::new()};
+            url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
+            checksum: None
+        });
         dependencies = Vec::new();
         dependencies.push(dependency.clone());
 
         let hashes = download_dependencies(&dependencies, true).await.unwrap();
         let path_zip =
-            DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name, &dependency.version));
+            DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name(), &dependency.version()));
         assert!(!path_zip_old.exists());
         assert!(path_zip.exists());
         assert!(hashes.len() == 1);
@@ -596,11 +603,12 @@ mod tests {
     async fn download_dependencies_http_one_fail() {
         let mut dependencies: Vec<Dependency> = Vec::new();
 
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~.zip".to_string(),
-            hash: String::new()};
+            url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~.zip".to_string()),
+            checksum: None
+        });
         dependencies.push(dependency.clone());
 
         match download_dependencies(&dependencies, false).await {
@@ -619,12 +627,12 @@ mod tests {
     async fn download_dependencies_git_one_fail() {
         let mut dependencies: Vec<Dependency> = Vec::new();
 
-        let dependency = Dependency {
+        let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "git@github.com:transmissions11/solmate-wrong.git".to_string(),
-            hash: String::new(),
-        };
+            git: "git@github.com:transmissions11/solmate-wrong.git".to_string(),
+            rev: None,
+        });
         dependencies.push(dependency.clone());
 
         match download_dependencies(&dependencies, false).await {
@@ -644,14 +652,15 @@ mod tests {
     #[serial]
     async fn unzip_dependency_success() {
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string(),
-            hash: String::new() };
+            url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
+            checksum: None
+        });
         dependencies.push(dependency.clone());
         download_dependencies(&dependencies, false).await.unwrap();
-        let path = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name, &dependency.version));
+        let path = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         match unzip_dependencies(&dependencies) {
             Ok(_) => {
                 assert!(path.exists());
@@ -669,13 +678,15 @@ mod tests {
     #[serial]
     async fn unzip_non_zip_file_error() {
         let mut dependencies: Vec<Dependency> = Vec::new();
-        let dependency = Dependency {
+        let dependency = Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "https://freetestdata.com/wp-content/uploads/2022/02/Free_Test_Data_117KB_JPG.jpg"
-                .to_string(),
-            hash: String::new(),
-        };
+            url: Some(
+                "https://freetestdata.com/wp-content/uploads/2022/02/Free_Test_Data_117KB_JPG.jpg"
+                    .to_string(),
+            ),
+            checksum: None,
+        });
         dependencies.push(dependency.clone());
         download_dependencies(&dependencies, false).await.unwrap();
         match unzip_dependencies(&dependencies) {
@@ -687,8 +698,8 @@ mod tests {
                 assert_eq!(
                     err,
                     UnzippingError {
-                        name: dependency.name.to_string(),
-                        version: dependency.version.to_string(),
+                        name: dependency.name().to_string(),
+                        version: dependency.version().to_string(),
                     }
                 );
             }
@@ -700,14 +711,14 @@ mod tests {
     #[serial]
     async fn download_unzip_check_integrity() {
         let mut dependencies: Vec<Dependency> = Vec::new();
-        dependencies.push(Dependency {
+        dependencies.push(Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "3.3.0-custom-test".to_string(),
-            url: "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/3_3_0-rc_2_22-01-2024_13:12:57_contracts.zip".to_string(),
-            hash: String::new()
-        });
+            url: Some("https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/3_3_0-rc_2_22-01-2024_13:12:57_contracts.zip".to_string()),
+            checksum: None,
+        }));
         download_dependencies(&dependencies, false).await.unwrap();
-        unzip_dependency(&dependencies[0].name, &dependencies[0].version).unwrap();
+        unzip_dependency(&dependencies[0].name(), &dependencies[0].version()).unwrap();
         healthcheck_dependency(&dependencies[0]).unwrap();
         assert!(DEPENDENCY_DIR
             .join("@openzeppelin-contracts-3.3.0-custom-test")
@@ -721,21 +732,27 @@ mod tests {
     #[test]
     fn get_download_tunnel_http() {
         assert_eq!(
-            get_download_tunnel(
+            get_dependency_type(
                 "https://github.com/foundry-rs/forge-std/archive/refs/tags/v1.9.1.zip"
             ),
-            "http"
+            DependencyType::Http
         );
     }
 
     #[test]
     fn get_download_tunnel_git_giturl() {
-        assert_eq!(get_download_tunnel("git@github.com:foundry-rs/forge-std.git"), "git");
+        assert_eq!(
+            get_dependency_type("git@github.com:foundry-rs/forge-std.git"),
+            DependencyType::Git
+        );
     }
 
     #[test]
     fn get_download_tunnel_git_githttp() {
-        assert_eq!(get_download_tunnel("https://github.com/foundry-rs/forge-std.git"), "git");
+        assert_eq!(
+            get_dependency_type("https://github.com/foundry-rs/forge-std.git"),
+            DependencyType::Git
+        );
     }
 
     #[test]
@@ -775,12 +792,12 @@ mod tests {
     async fn remove_one_dependency() {
         let mut dependencies: Vec<Dependency> = Vec::new();
 
-        let dependency = Dependency {
+        let dependency = Dependency::Git(GitDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "2.3.0".to_string(),
-            url: "git@github.com:transmissions11/solmate.git".to_string(),
-            hash: String::new(),
-        };
+            git: "git@github.com:transmissions11/solmate.git".to_string(),
+            rev: None,
+        });
         dependencies.push(dependency.clone());
 
         match download_dependencies(&dependencies, false).await {
@@ -791,7 +808,7 @@ mod tests {
         }
         let _ = delete_dependency_files(&dependency);
         assert!(!DEPENDENCY_DIR
-            .join(format!("{}~{}", dependency.name, dependency.version))
+            .join(format!("{}~{}", dependency.name(), dependency.version()))
             .exists());
     }
 }

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -13,7 +13,7 @@ use std::{
     process::{Command, Stdio},
     str,
 };
-use tokio::{fs as tokio_fs, io::AsyncWriteExt as _, task::JoinSet};
+use tokio::{fs as tokio_fs, io::AsyncWriteExt, task::JoinSet};
 use yansi::Paint as _;
 
 pub type Result<T> = std::result::Result<T, DownloadError>;
@@ -242,6 +242,8 @@ async fn download_via_http(
             .await
             .map_err(|e| DownloadError::IOError { path: file_path.clone(), source: e })?;
     }
+    // make sure we finished writing the file
+    file.flush().await.map_err(|e| DownloadError::IOError { path: file_path, source: e })?;
     Ok(())
 }
 

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -180,7 +180,7 @@ async fn download_via_git(
         Some(rev) => {
             let result = git_get_commit
                 .args([
-                    format!("--work-tree={:?}", path),
+                    format!("--work-tree={}", path_str),
                     format!("--git-dir={}", path.join(".git").to_string_lossy()),
                     "checkout".to_string(),
                     rev.to_string(),
@@ -205,7 +205,7 @@ async fn download_via_git(
         None => {
             let result = git_checkout
                 .args([
-                    format!("--work-tree={:?}", path),
+                    format!("--work-tree={}", path_str),
                     format!("--git-dir={}", path.join(".git").to_string_lossy()),
                     "rev-parse".to_string(),
                     "--verify".to_string(),

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -253,10 +253,20 @@ async fn download_via_http(
     dependency_directory: &Path,
 ) -> Result<(), DownloadError> {
     let zip_to_download = &format!("{}-{}.zip", dependency.name, dependency.version);
-    let mut resp = reqwest::get(url).await.map_err(|e| DownloadError {
+    let resp = reqwest::get(url).await.map_err(|e| DownloadError {
         name: dependency.name.clone(),
         version: dependency.version.clone(),
         cause: format!("Error downloading zip file: {e:?}"),
+    })?;
+    let mut resp = resp.error_for_status().map_err(|e| DownloadError {
+        name: dependency.name.clone(),
+        version: dependency.version.clone(),
+        cause: format!(
+            "Dependency {}~{} could not be downloaded via http.\nStatus: {}",
+            dependency.name.clone(),
+            dependency.version.clone(),
+            e.status().unwrap_or_default()
+        ),
     })?;
 
     let mut file =

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -77,7 +77,7 @@ pub async fn download_dependency(dependency: &Dependency) -> Result<DownloadResu
     };
     println!(
         "{}",
-        &format!("Dependency {}-{} downloaded!", dependency.name(), dependency.version()).green()
+        format!("Dependency {}-{} downloaded!", dependency.name(), dependency.version()).green()
     );
 
     Ok(res)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -77,6 +77,9 @@ pub enum ConfigError {
 
     #[error("dependency {0} was not found")]
     MissingDependency(String),
+
+    #[error("error parsing config file: {0}")]
+    DeserializeError(#[from] toml_edit::de::Error),
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,6 @@
-use std::fmt;
+use std::{fmt, io};
+
+use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SoldeerError {
@@ -116,15 +118,40 @@ impl LoginError {
         LoginError { cause: cause.to_string() }
     }
 }
-#[derive(Debug, Clone, PartialEq)]
-pub struct ConfigError {
-    pub cause: String,
-}
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("config file not found")]
+    NotFound,
 
-impl ConfigError {
-    pub fn new(cause: &str) -> ConfigError {
-        ConfigError { cause: cause.to_string() }
-    }
+    #[error("config file is not valid: {0}")]
+    Parsing(#[from] toml_edit::TomlError),
+
+    #[error("config file is missing the `[dependencies]` section")]
+    MissingDependencies,
+
+    #[error("invalid user input: {source}")]
+    PromptError { source: io::Error },
+
+    #[error("invalid prompt option")]
+    InvalidPromptOption,
+
+    #[error("error writing to config file: {0}")]
+    FileWriteError(#[from] io::Error),
+
+    #[error("empty `version` field in {0}")]
+    EmptyVersion(String),
+
+    #[error("missing `{field}` field in {dep}")]
+    MissingField { field: String, dep: String },
+
+    #[error("invalid `{field}` field in {dep}")]
+    InvalidField { field: String, dep: String },
+
+    #[error("dependency {0} is not valid")]
+    InvalidDependency(String),
+
+    #[error("dependency {0} was not found")]
+    MissingDependency(String),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,27 +59,28 @@ impl fmt::Display for LockError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct DownloadError {
-    pub name: String,
-    pub version: String,
-    pub cause: String,
-}
+#[derive(Error, Debug)]
+pub enum DownloadError {
+    #[error("error downloading dependency: {0}")]
+    HttpError(#[from] reqwest::Error),
 
-impl fmt::Display for DownloadError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "download failed for {}~{}", &self.name, &self.version)
-    }
-}
+    #[error("error extracting dependency: {0}")]
+    UnzipError(#[from] zip_extract::ZipExtractError),
 
-impl DownloadError {
-    pub fn new(name: &str, version: &str, cause: &str) -> DownloadError {
-        DownloadError {
-            name: name.to_string(),
-            version: version.to_string(),
-            cause: cause.to_string(),
-        }
-    }
+    #[error("error during git operation: {0}")]
+    GitError(String),
+
+    #[error("error during IO operation: {0}")]
+    IOError(#[from] io::Error),
+
+    #[error("Project {0} not found, please check the dependency name (project name) or create a new project on https://soldeer.xyz")]
+    ProjectNotFound(String),
+
+    #[error("Could not get the dependency URL for {0}")]
+    URLNotFound(String),
+
+    #[error("Could not get the last forge dependency")]
+    ForgeStdError,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,6 +60,9 @@ pub enum ConfigError {
     #[error("error writing to config file: {0}")]
     FileWriteError(#[from] io::Error),
 
+    #[error("error writing to remappings file: {0}")]
+    RemappingsError(io::Error),
+
     #[error("empty `version` field in {0}")]
     EmptyVersion(String),
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,4 @@
 use std::{fmt, io};
-
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -120,9 +119,6 @@ impl LoginError {
 }
 #[derive(Error, Debug)]
 pub enum ConfigError {
-    #[error("config file not found")]
-    NotFound,
-
     #[error("config file is not valid: {0}")]
     Parsing(#[from] toml_edit::TomlError),
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,15 +25,22 @@ impl PushError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct LoginError {
-    pub cause: String,
-}
+#[derive(Error, Debug)]
+pub enum AuthError {
+    #[error("login error: invalid email")]
+    InvalidEmail,
 
-impl LoginError {
-    pub fn new(cause: &str) -> LoginError {
-        LoginError { cause: cause.to_string() }
-    }
+    #[error("login error: invalid email or password")]
+    InvalidCredentials,
+
+    #[error("missing token, you are not connected")]
+    MissingToken,
+
+    #[error("error during IO operation for the security file: {0}")]
+    IOError(#[from] io::Error),
+
+    #[error("http error during login: {0}")]
+    HttpError(#[from] reqwest::Error),
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -101,6 +101,9 @@ pub enum DownloadError {
 
     #[error("Could not get the last forge dependency")]
     ForgeStdError,
+
+    #[error("error during async operation: {0}")]
+    AsyncError(#[from] tokio::task::JoinError),
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,7 +12,7 @@ pub enum SoldeerError {
     #[error("error during config operation: {0}")]
     ConfigError(#[from] ConfigError),
 
-    #[error("error during downloading of {dep}: {source}")]
+    #[error("error during downloading ({dep}): {source}")]
     DownloadError { dep: String, source: DownloadError },
 
     #[error("error during janitor operation: {0}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,29 +13,6 @@ impl fmt::Display for SoldeerError {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct MissingDependencies {
-    pub name: String,
-    pub version: String,
-}
-
-impl MissingDependencies {
-    pub fn new(name: &str, version: &str) -> MissingDependencies {
-        MissingDependencies { name: name.to_string(), version: version.to_string() }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct LockError {
-    pub cause: String,
-}
-
-impl fmt::Display for LockError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "lock failed")
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub struct PushError {
     pub name: String,
     pub version: String,
@@ -57,6 +34,21 @@ impl LoginError {
     pub fn new(cause: &str) -> LoginError {
         LoginError { cause: cause.to_string() }
     }
+}
+
+#[derive(Error, Debug)]
+pub enum LockError {
+    #[error("soldeer.lock is missing")]
+    Missing,
+
+    #[error("dependency {0} is already installed")]
+    DependencyInstalled(String),
+
+    #[error("IO error for soldeer.lock: {0}")]
+    IOError(#[from] io::Error),
+
+    #[error("error generating soldeer.lock contents: {0}")]
+    SerializeError(#[from] toml_edit::ser::Error),
 }
 
 #[derive(Error, Debug)]

--- a/src/janitor.rs
+++ b/src/janitor.rs
@@ -45,21 +45,16 @@ mod tests {
     use super::*;
     use crate::{
         config::HttpDependency,
-        dependency_downloader::{download_dependencies, unzip_dependency},
+        dependency_downloader::{
+            clean_dependency_directory, download_dependencies, unzip_dependency,
+        },
     };
     use serial_test::serial;
-
-    fn clean_dependency_directory_sync() {
-        if DEPENDENCY_DIR.is_dir() {
-            fs::remove_dir_all(DEPENDENCY_DIR.clone()).unwrap();
-            fs::create_dir(DEPENDENCY_DIR.clone()).unwrap();
-        }
-    }
 
     struct CleanupDependency;
     impl Drop for CleanupDependency {
         fn drop(&mut self) {
-            clean_dependency_directory_sync();
+            clean_dependency_directory();
         }
     }
 
@@ -141,7 +136,7 @@ mod tests {
         let _ = unzip_dependency(dependencies[0].as_http().unwrap());
         let result: Result<()> = cleanup_after(&dependencies);
         assert!(result.is_ok());
-        clean_dependency_directory_sync();
+        clean_dependency_directory();
     }
 
     #[tokio::test]

--- a/src/janitor.rs
+++ b/src/janitor.rs
@@ -45,16 +45,21 @@ mod tests {
     use super::*;
     use crate::{
         config::HttpDependency,
-        dependency_downloader::{
-            clean_dependency_directory, download_dependencies, unzip_dependency,
-        },
+        dependency_downloader::{download_dependencies, unzip_dependency},
     };
     use serial_test::serial;
+
+    fn clean_dependency_directory_sync() {
+        if DEPENDENCY_DIR.is_dir() {
+            fs::remove_dir_all(DEPENDENCY_DIR.clone()).unwrap();
+            fs::create_dir(DEPENDENCY_DIR.clone()).unwrap();
+        }
+    }
 
     struct CleanupDependency;
     impl Drop for CleanupDependency {
         fn drop(&mut self) {
-            clean_dependency_directory();
+            clean_dependency_directory_sync();
         }
     }
 
@@ -136,7 +141,7 @@ mod tests {
         let _ = unzip_dependency(dependencies[0].as_http().unwrap());
         let result: Result<()> = cleanup_after(&dependencies);
         assert!(result.is_ok());
-        clean_dependency_directory();
+        clean_dependency_directory_sync();
     }
 
     #[tokio::test]

--- a/src/janitor.rs
+++ b/src/janitor.rs
@@ -81,7 +81,7 @@ mod tests {
             url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
             checksum: None}));
         download_dependencies(&dependencies, false).await.unwrap();
-        unzip_dependency(dependencies[0].name(), dependencies[0].version()).unwrap();
+        unzip_dependency(dependencies[0].as_http().unwrap()).unwrap();
         healthcheck_dependency(&dependencies[0]).unwrap();
     }
 
@@ -97,7 +97,7 @@ mod tests {
             url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
             checksum: None }));
         download_dependencies(&dependencies, false).await.unwrap();
-        unzip_dependency(dependencies[0].name(), dependencies[0].version()).unwrap();
+        unzip_dependency(dependencies[0].as_http().unwrap()).unwrap();
         cleanup_dependency(&dependencies[0], false).unwrap();
     }
 
@@ -133,7 +133,7 @@ mod tests {
             checksum: None }));
 
         download_dependencies(&dependencies, false).await.unwrap();
-        let _ = unzip_dependency(dependencies[0].name(), dependencies[0].version());
+        let _ = unzip_dependency(dependencies[0].as_http().unwrap());
         let result: Result<()> = cleanup_after(&dependencies);
         assert!(result.is_ok());
         clean_dependency_directory();
@@ -152,7 +152,7 @@ mod tests {
             checksum: None}));
 
         download_dependencies(&dependencies, false).await.unwrap();
-        unzip_dependency(dependencies[0].name(), dependencies[0].version()).unwrap();
+        unzip_dependency(dependencies[0].as_http().unwrap()).unwrap();
         dependencies.push(Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),
             version: "cleanup-after-one-existing-2".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
 async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerError> {
     lock_check(&dependency, true)?;
 
-    let result = download_dependency(&dependency)
+    let result = download_dependency(&dependency, false)
         .await
         .map_err(|e| SoldeerError::DownloadError { dep: dependency.to_string(), source: e })?;
     match dependency {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,12 +252,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
                 match janitor::cleanup_dependency(&dependency, true) {
                     Ok(_) => {}
                     Err(err_cleanup) => {
-                        return Err(SoldeerError {
-                            message: format!(
-                                "Error cleaning up dependency {}~{}",
-                                err_cleanup.name, err_cleanup.version
-                            ),
-                        })
+                        return Err(SoldeerError { message: err_cleanup.to_string() })
                     }
                 }
                 return Err(SoldeerError { message: err_unzip.to_string() });
@@ -292,18 +287,14 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
     match janitor::healthcheck_dependency(&dependency) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError {
-                message: format!("Error health-checking dependency {}~{}", err.name, err.version),
-            });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 
     match janitor::cleanup_dependency(&dependency, false) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError {
-                message: format!("Error cleaning up dependency {}~{}", err.name, err.version),
-            });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 
@@ -345,9 +336,7 @@ async fn update() -> Result<(), SoldeerError> {
     match healthcheck_dependencies(&dependencies) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError {
-                message: format!("Error health-checking dependencies {}~{}", err.name, err.version),
-            });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 
@@ -361,9 +350,7 @@ async fn update() -> Result<(), SoldeerError> {
     match cleanup_after(&dependencies) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError {
-                message: format!("Error cleanup dependencies {}~{}", err.name, err.version),
-            });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,12 +167,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             match push_version(&dependency_name, &dependency_version, path, dry_run).await {
                 Ok(_) => {}
                 Err(err) => {
-                    return Err(SoldeerError {
-                        message: format!(
-                            "Dependency {}~{} could not be pushed.\nCause: {}",
-                            dependency_name, dependency_version, err.cause
-                        ),
-                    });
+                    return Err(SoldeerError { message: err.to_string() });
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,12 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 match config::remove_forge_lib() {
                     Ok(_) => {}
                     Err(err) => {
-                        return Err(SoldeerError { message: err.cause });
+                        return Err(SoldeerError { message: err.to_string() }); // TODO: derive
+                                                                               // SoldeerError from
+                                                                               // module errors
+                                                                               // automatically,
+                                                                               // will enable use of
+                                                                               // ? operator
                     }
                 }
             }
@@ -192,7 +197,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             let dependency = match delete_config(&uninstall.dependency, &path) {
                 Ok(d) => d,
                 Err(err) => {
-                    return Err(SoldeerError { message: err.cause });
+                    return Err(SoldeerError { message: err.to_string() });
                 }
             };
 
@@ -295,7 +300,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
     match add_to_config(&dependency, &config_file) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError { message: err.cause });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 
@@ -318,7 +323,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
     }
 
     // TODO: check the config to know whether we should write remappings
-    remappings().await.map_err(|e| SoldeerError { message: e.cause })?;
+    remappings().await.map_err(|e| SoldeerError { message: e.to_string() })?;
     Ok(())
 }
 
@@ -327,7 +332,7 @@ async fn update() -> Result<(), SoldeerError> {
 
     let mut dependencies: Vec<Dependency> = match read_config(None) {
         Ok(dep) => dep,
-        Err(err) => return Err(SoldeerError { message: err.cause }),
+        Err(err) => return Err(SoldeerError { message: err.to_string() }),
     };
 
     let results = match download_dependencies(&dependencies, true).await {
@@ -387,7 +392,7 @@ async fn update() -> Result<(), SoldeerError> {
     }
 
     // TODO: check the config to know whether we should write remappings
-    remappings().await.map_err(|e| SoldeerError { message: e.cause })?;
+    remappings().await.map_err(|e| SoldeerError { message: e.to_string() })?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             remove_lock(&dependency)?;
         }
 
-        Subcommands::VersionDryRun(_) => {
+        Subcommands::Version(_) => {
             const VERSION: &str = env!("CARGO_PKG_VERSION");
             println!("{}", format!("Current Soldeer {}", VERSION).cyan());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 use crate::{
     auth::login,
     commands::Subcommands,
-    config::{delete_config, read_config, remappings, Dependency},
+    config::{delete_config, read_config_deps, remappings_txt, Dependency},
     dependency_downloader::{
         delete_dependency_files, download_dependencies, unzip_dependencies, unzip_dependency,
     },
@@ -201,14 +201,14 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
     janitor::cleanup_dependency(&dependency, false)?;
 
     // TODO: check the config to know whether we should write remappings
-    remappings().await?;
+    //remappings_txt().await?;
     Ok(())
 }
 
 async fn update() -> Result<(), SoldeerError> {
     println!("{}", "🦌 Running Soldeer update 🦌".green());
 
-    let mut dependencies: Vec<Dependency> = read_config(None)?;
+    let mut dependencies: Vec<Dependency> = read_config_deps(None)?;
 
     let results = download_dependencies(&dependencies, true)
         .await
@@ -234,7 +234,7 @@ async fn update() -> Result<(), SoldeerError> {
     cleanup_after(&dependencies)?;
 
     // TODO: check the config to know whether we should write remappings
-    remappings().await?;
+    //remappings_txt().await?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             match remove_lock(&dependency) {
                 Ok(d) => d,
                 Err(err) => {
-                    return Err(SoldeerError { message: err.cause });
+                    return Err(SoldeerError { message: err.to_string() });
                 }
             };
         }
@@ -220,7 +220,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
     match lock_check(&dependency, true) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError { message: err.cause });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 
@@ -241,7 +241,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
     match write_lock(&[dependency.clone()], LockWriteMode::Append) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError { message: format!("Error writing the lock: {}", err.cause) });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 
@@ -343,7 +343,7 @@ async fn update() -> Result<(), SoldeerError> {
     match write_lock(&dependencies, LockWriteMode::Replace) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError { message: format!("Error writing the lock: {}", err.cause) });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use remote::get_latest_forge_std_dependency;
 use std::{env, path::PathBuf};
 use utils::{get_dependency_type, DependencyType};
 use versioning::validate_name;
-use yansi::Paint;
+use yansi::Paint as _;
 
 mod auth;
 pub mod commands;
@@ -46,8 +46,8 @@ pub static FOUNDRY_CONFIG_FILE: Lazy<PathBuf> =
 pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
     match command {
         Subcommands::Init(init) => {
-            Paint::green("🦌 Running Soldeer init 🦌\n");
-            Paint::green("Initializes a new Soldeer project in foundry\n");
+            println!("{}", "🦌 Running Soldeer init 🦌".green());
+            println!("{}", "Initializes a new Soldeer project in foundry".green());
 
             if init.clean.is_some() && init.clean.unwrap() {
                 config::remove_forge_lib()?;
@@ -64,7 +64,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                                        // integrity checksum and install those
             };
 
-            Paint::green("🦌 Running Soldeer install 🦌\n");
+            println!("{}", "🦌 Running Soldeer install 🦌".green());
             let (dependency_name, dependency_version) =
                 dependency.split_once('~').expect("dependency string should have name and version");
 
@@ -97,7 +97,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             return update().await;
         }
         Subcommands::Login(_) => {
-            Paint::green("🦌 Running Soldeer login 🦌\n");
+            println!("{}", "🦌 Running Soldeer login 🦌".green());
             login().await?;
         }
         Subcommands::Push(push) => {
@@ -111,24 +111,21 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 check_dotfiles_recursive(&path) &&
                 !prompt_user_for_confirmation()
             {
-                Paint::yellow("Push operation aborted by the user.");
+                println!("{}", "Push operation aborted by the user.".yellow());
                 return Ok(());
             }
 
             if dry_run {
                 println!(
                     "{}",
-                    Paint::green("🦌 Running Soldeer push with dry-run, a zip file will be available for inspection 🦌\n")
+                    "🦌 Running Soldeer push with dry-run, a zip file will be available for inspection 🦌".green()
                 );
             } else {
-                Paint::green("🦌 Running Soldeer push 🦌\n");
+                println!("{}", "🦌 Running Soldeer push 🦌".green());
             }
 
             if skip_warnings {
-                println!(
-                    "{}",
-                    Paint::yellow("Warning: Skipping sensitive file checks as requested.")
-                );
+                println!("{}", "Warning: Skipping sensitive file checks as requested.".yellow());
             }
 
             let (dependency_name, dependency_version) = push
@@ -160,7 +157,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
 
         Subcommands::VersionDryRun(_) => {
             const VERSION: &str = env!("CARGO_PKG_VERSION");
-            Paint::cyan(&format!("Current Soldeer {}", VERSION));
+            println!("{}", format!("Current Soldeer {}", VERSION).cyan());
         }
     }
     Ok(())
@@ -209,7 +206,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
 }
 
 async fn update() -> Result<(), SoldeerError> {
-    Paint::green("🦌 Running Soldeer update 🦌\n");
+    println!("{}", "🦌 Running Soldeer update 🦌".green());
 
     let mut dependencies: Vec<Dependency> = read_config(None)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
     write_lock(&[dependency.clone()], LockWriteMode::Append)?;
 
     if let Dependency::Http(dep) = &dependency {
-        if let Err(e) = unzip_dependency(&dep.name, &dep.version) {
+        if let Err(e) = unzip_dependency(dep) {
             cleanup_dependency(&dependency, true)?;
             return Err(SoldeerError::DownloadError { dep: dependency.to_string(), source: e });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
 async fn update() -> Result<(), SoldeerError> {
     Paint::green("🦌 Running Soldeer update 🦌\n");
 
-    let mut dependencies: Vec<Dependency> = match read_config(None).await {
+    let mut dependencies: Vec<Dependency> = match read_config(None) {
         Ok(dep) => dep,
         Err(err) => return Err(SoldeerError { message: err.cause }),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1138,7 +1138,7 @@ libs = ["dependencies"]
         }
 
         let path = env::current_dir().unwrap().join("test").join(target);
-        env::set_var("config_file", path.clone().to_str().unwrap());
+        env::set_var("config_file", path.to_string_lossy().to_string());
         path
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,16 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 use crate::{
     auth::login,
-    commands::Subcommands,
     config::{delete_config, read_config_deps, remappings_txt, Dependency},
     dependency_downloader::{
         delete_dependency_files, download_dependencies, unzip_dependencies, unzip_dependency,
     },
-    errors::SoldeerError,
     janitor::{cleanup_after, healthcheck_dependencies},
     lock::{lock_check, remove_lock, write_lock},
     utils::{check_dotfiles_recursive, get_current_working_dir, prompt_user_for_confirmation},
     versioning::push_version,
 };
+pub use crate::{commands::Subcommands, errors::SoldeerError};
 use config::{
     add_to_config, get_config_path, read_soldeer_config, remappings_foundry, GitDependency,
     HttpDependency, RemappingsAction, RemappingsLocation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,10 +112,10 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             let skip_warnings = push.skip_warnings;
 
             // Check for sensitive files or directories
-            if !dry_run
-                && !skip_warnings
-                && check_dotfiles_recursive(&path)
-                && !prompt_user_for_confirmation()
+            if !dry_run &&
+                !skip_warnings &&
+                check_dotfiles_recursive(&path) &&
+                !prompt_user_for_confirmation()
             {
                 println!("{}", "Push operation aborted by the user.".yellow());
                 return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,10 +112,10 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             let skip_warnings = push.skip_warnings;
 
             // Check for sensitive files or directories
-            if !dry_run &&
-                !skip_warnings &&
-                check_dotfiles_recursive(&path) &&
-                !prompt_user_for_confirmation()
+            if !dry_run
+                && !skip_warnings
+                && check_dotfiles_recursive(&path)
+                && !prompt_user_for_confirmation()
             {
                 println!("{}", "Push operation aborted by the user.".yellow());
                 return Ok(());
@@ -344,7 +344,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Install(Install {
             dependency: None,
@@ -392,7 +395,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Install(Install {
             dependency: None,
@@ -438,7 +444,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Update(Update { regenerate_remappings: false });
 
@@ -481,7 +490,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Update(Update { regenerate_remappings: false });
 
@@ -536,7 +548,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Install(Install {
             dependency: None,
@@ -722,7 +737,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
@@ -774,7 +792,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
@@ -826,7 +847,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
@@ -878,7 +902,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
@@ -930,7 +957,10 @@ libs = ["dependencies"]
 
         write_to_config(&target_config, content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Install(Install {
             dependency: Some("forge-std~1.9.1".to_string()),
@@ -966,7 +996,10 @@ libs = ["dependencies"]
         let content = String::new();
         write_to_config(&target_config, &content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Init(Init { clean: false });
 
@@ -1015,7 +1048,10 @@ libs = ["dependencies"]
         let content = String::new();
         write_to_config(&target_config, &content);
 
-        env::set_var("base_url", "https://api.soldeer.xyz");
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("base_url", "https://api.soldeer.xyz");
+        }
 
         let command = Subcommands::Init(Init { clean: true });
 
@@ -1068,7 +1104,10 @@ libs = ["dependencies"]
         }
 
         let path = env::current_dir().unwrap().join("test").join(target);
-        env::set_var("config_file", path.to_string_lossy().to_string());
+        unsafe {
+            // became unsafe in Rust 1.80
+            env::set_var("config_file", path.to_string_lossy().to_string());
+        }
         path
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             match login().await {
                 Ok(_) => {}
                 Err(err) => {
-                    return Err(SoldeerError { message: err.cause });
+                    return Err(SoldeerError { message: err.to_string() });
                 }
             }
         }
@@ -713,7 +713,7 @@ libs = ["dependencies"]
                 clean_test_env(PathBuf::default());
 
                 // Check if the error is due to not being logged in
-                if e.message.contains("You are not logged in") {
+                if e.message.contains("you are not connected") {
                     println!(
                         "Test skipped: User not logged in. This test requires a logged-in state."
                     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use lock::LockWriteMode;
 use once_cell::sync::Lazy;
 use remote::get_latest_forge_std_dependency;
 use std::{env, path::PathBuf};
-use utils::{get_dependency_type, DependencyType};
+use utils::{get_url_type, UrlType};
 use versioning::validate_name;
 use yansi::Paint as _;
 
@@ -69,14 +69,14 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 dependency.split_once('~').expect("dependency string should have name and version");
 
             let dep = match install.remote_url {
-                Some(url) => match get_dependency_type(&url) {
-                    DependencyType::Git => Dependency::Git(GitDependency {
+                Some(url) => match get_url_type(&url) {
+                    UrlType::Git => Dependency::Git(GitDependency {
                         name: dependency_name.to_string(),
                         version: dependency_version.to_string(),
                         git: url,
                         rev: install.rev,
                     }),
-                    DependencyType::Http => Dependency::Http(HttpDependency {
+                    UrlType::Http => Dependency::Http(HttpDependency {
                         name: dependency_name.to_string(),
                         version: dependency_version.to_string(),
                         url: Some(url),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,8 +280,12 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command =
-            Subcommands::Install(Install { dependency: None, remote_url: None, rev: None });
+        let command = Subcommands::Install(Install {
+            dependency: None,
+            remote_url: None,
+            rev: None,
+            reg_remappings: None,
+        });
 
         match run(command) {
             Ok(_) => {}
@@ -324,8 +328,12 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command =
-            Subcommands::Install(Install { dependency: None, remote_url: None, rev: None });
+        let command = Subcommands::Install(Install {
+            dependency: None,
+            remote_url: None,
+            rev: None,
+            reg_remappings: None,
+        });
 
         match run(command) {
             Ok(_) => {}
@@ -366,7 +374,7 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command = Subcommands::Update(Update {});
+        let command = Subcommands::Update(Update { reg_remappings: None });
 
         match run(command) {
             Ok(_) => {}
@@ -409,7 +417,7 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command = Subcommands::Update(Update {});
+        let command = Subcommands::Update(Update { reg_remappings: None });
 
         match run(command) {
             Ok(_) => {}
@@ -464,8 +472,12 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command =
-            Subcommands::Install(Install { dependency: None, remote_url: None, rev: None });
+        let command = Subcommands::Install(Install {
+            dependency: None,
+            remote_url: None,
+            rev: None,
+            reg_remappings: None,
+        });
 
         match run(command) {
             Ok(_) => {}
@@ -650,6 +662,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Option::None,
             rev: None,
+            reg_remappings: None,
         });
 
         match run(command) {
@@ -701,6 +714,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("https://soldeer-revisions.s3.amazonaws.com/forge-std/v1_9_0_03-07-2024_14:44:57_forge-std-v1.9.0.zip".to_string()),
             rev: None,
+            reg_remappings: None
         });
 
         match run(command) {
@@ -752,6 +766,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("https://github.com/foundry-rs/forge-std.git".to_string()),
             rev: None,
+            reg_remappings: None,
         });
 
         match run(command) {
@@ -803,6 +818,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
             rev: None,
+            reg_remappings: None,
         });
 
         match run(command) {
@@ -854,6 +870,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
             rev: Some("3778c3cb8e4244cb5a1c3ef3ce1c71a3683e324a".to_string()),
+            reg_remappings: None,
         });
 
         match run(command) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,12 +66,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             let dependency: Dependency = match get_latest_forge_std_dependency().await {
                 Ok(dep) => dep,
                 Err(err) => {
-                    return Err(SoldeerError {
-                        message: format!(
-                            "Error downloading a dependency {}~{}",
-                            err.name, err.version
-                        ),
-                    });
+                    return Err(SoldeerError { message: err.to_string() });
                 }
             };
             match install_dependency(dependency).await {
@@ -232,12 +227,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
     let result = match download_dependency(&dependency).await {
         Ok(h) => h,
         Err(err) => {
-            return Err(SoldeerError {
-                message: format!(
-                    "Error downloading a dependency {}~{}. Cause: {}",
-                    err.name, err.version, err.cause
-                ),
-            });
+            return Err(SoldeerError { message: err.to_string() });
         }
     };
     match dependency {
@@ -270,12 +260,7 @@ async fn install_dependency(mut dependency: Dependency) -> Result<(), SoldeerErr
                         })
                     }
                 }
-                return Err(SoldeerError {
-                    message: format!(
-                        "Error downloading a dependency {}~{}",
-                        err_unzip.name, err_unzip.version
-                    ),
-                });
+                return Err(SoldeerError { message: err_unzip.to_string() });
             }
         }
     }
@@ -337,14 +322,7 @@ async fn update() -> Result<(), SoldeerError> {
 
     let results = match download_dependencies(&dependencies, true).await {
         Ok(h) => h,
-        Err(err) => {
-            return Err(SoldeerError {
-                message: format!(
-                    "Error downloading a dependency {}~{}. Cause: {}",
-                    err.name, err.version, err.cause
-                ),
-            })
-        }
+        Err(err) => return Err(SoldeerError { message: err.to_string() }),
     };
 
     dependencies.iter_mut().zip(results.into_iter()).for_each(|(dependency, result)| {
@@ -360,9 +338,7 @@ async fn update() -> Result<(), SoldeerError> {
     match unzip_dependencies(&dependencies) {
         Ok(_) => {}
         Err(err) => {
-            return Err(SoldeerError {
-                message: format!("Error unzipping dependency {}~{}", err.name, err.version),
-            });
+            return Err(SoldeerError { message: err.to_string() });
         }
     }
 
@@ -630,7 +606,7 @@ libs = ["dependencies"]
             Err(err) => {
                 clean_test_env(target_config.clone());
                 // can not generalize as diff systems return various dns errors
-                assert!(err.message.contains("Error downloading a dependency will-fail~1"))
+                assert!(err.message.contains("error sending request for url"))
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             println!("{}", "🦌 Running Soldeer init 🦌".green());
             println!("{}", "Initializes a new Soldeer project in foundry".green());
 
-            if init.clean.is_some() && init.clean.unwrap() {
+            if init.clean {
                 config::remove_forge_lib()?;
             }
 
@@ -62,7 +62,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             install_dependency(dependency, true).await?;
         }
         Subcommands::Install(install) => {
-            let regenerate_remappings = install.regenerate_remappings.unwrap_or(false);
+            let regenerate_remappings = install.regenerate_remappings;
             let Some(dependency) = install.dependency else {
                 return update(regenerate_remappings).await; // TODO: instead, check which
                                                             // dependencies do
@@ -100,7 +100,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             install_dependency(dep, regenerate_remappings).await?;
         }
         Subcommands::Update(update_args) => {
-            let regenerate_remappings = update_args.regenerate_remappings.unwrap_or(false);
+            let regenerate_remappings = update_args.regenerate_remappings;
             return update(regenerate_remappings).await;
         }
         Subcommands::Login(_) => {
@@ -109,8 +109,8 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
         }
         Subcommands::Push(push) => {
             let path = push.path.unwrap_or(get_current_working_dir());
-            let dry_run = push.dry_run.is_some() && push.dry_run.unwrap();
-            let skip_warnings = push.skip_warnings.unwrap_or(false);
+            let dry_run = push.dry_run;
+            let skip_warnings = push.skip_warnings;
 
             // Check for sensitive files or directories
             if !dry_run &&
@@ -329,7 +329,7 @@ libs = ["dependencies"]
             dependency: None,
             remote_url: None,
             rev: None,
-            regenerate_remappings: None,
+            regenerate_remappings: false,
         });
 
         match run(command) {
@@ -377,7 +377,7 @@ libs = ["dependencies"]
             dependency: None,
             remote_url: None,
             rev: None,
-            regenerate_remappings: None,
+            regenerate_remappings: false,
         });
 
         match run(command) {
@@ -419,7 +419,7 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command = Subcommands::Update(Update { regenerate_remappings: None });
+        let command = Subcommands::Update(Update { regenerate_remappings: false });
 
         match run(command) {
             Ok(_) => {}
@@ -462,7 +462,7 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command = Subcommands::Update(Update { regenerate_remappings: None });
+        let command = Subcommands::Update(Update { regenerate_remappings: false });
 
         match run(command) {
             Ok(_) => {}
@@ -521,7 +521,7 @@ libs = ["dependencies"]
             dependency: None,
             remote_url: None,
             rev: None,
-            regenerate_remappings: None,
+            regenerate_remappings: false,
         });
 
         match run(command) {
@@ -559,8 +559,8 @@ libs = ["dependencies"]
         let command = Subcommands::Push(Push {
             dependency: "@test~1.1".to_string(),
             path: Some(path_dependency.clone()),
-            dry_run: Some(true),
-            skip_warnings: None,
+            dry_run: true,
+            skip_warnings: false,
         });
 
         match run(command) {
@@ -597,8 +597,8 @@ libs = ["dependencies"]
         let command = Subcommands::Push(Push {
             dependency: "@test~1.1".to_string(),
             path: Some(test_dir.clone()),
-            dry_run: None,
-            skip_warnings: None,
+            dry_run: false,
+            skip_warnings: false,
         });
 
         match run(command) {
@@ -637,8 +637,8 @@ libs = ["dependencies"]
         let command = Subcommands::Push(Push {
             dependency: "@test~1.1".to_string(),
             path: Some(test_dir.clone()),
-            dry_run: None,
-            skip_warnings: Some(true),
+            dry_run: false,
+            skip_warnings: true,
         });
 
         match run(command) {
@@ -707,7 +707,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Option::None,
             rev: None,
-            regenerate_remappings: None,
+            regenerate_remappings: false,
         });
 
         match run(command) {
@@ -759,7 +759,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("https://soldeer-revisions.s3.amazonaws.com/forge-std/v1_9_0_03-07-2024_14:44:57_forge-std-v1.9.0.zip".to_string()),
             rev: None,
-            regenerate_remappings: None
+            regenerate_remappings: false
         });
 
         match run(command) {
@@ -811,7 +811,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("https://github.com/foundry-rs/forge-std.git".to_string()),
             rev: None,
-            regenerate_remappings: None,
+            regenerate_remappings: false,
         });
 
         match run(command) {
@@ -863,7 +863,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
             rev: None,
-            regenerate_remappings: None,
+            regenerate_remappings: false,
         });
 
         match run(command) {
@@ -915,7 +915,7 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
             rev: Some("3778c3cb8e4244cb5a1c3ef3ce1c71a3683e324a".to_string()),
-            regenerate_remappings: None,
+            regenerate_remappings: false,
         });
 
         match run(command) {
@@ -947,7 +947,7 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command = Subcommands::Init(Init { clean: None });
+        let command = Subcommands::Init(Init { clean: false });
 
         match run(command) {
             Ok(_) => {}
@@ -996,7 +996,7 @@ libs = ["dependencies"]
 
         env::set_var("base_url", "https://api.soldeer.xyz");
 
-        let command = Subcommands::Init(Init { clean: Some(true) });
+        let command = Subcommands::Init(Init { clean: true });
 
         match run(command) {
             Ok(_) => {}

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use serde_derive::{Deserialize, Serialize};
 use std::{fs, path::PathBuf};
-use yansi::Paint;
+use yansi::Paint as _;
 
 pub type Result<T> = std::result::Result<T, LockError>;
 
@@ -94,17 +94,14 @@ pub fn write_lock(dependencies: &[Dependency], mode: LockWriteMode) -> Result<()
         // check for entry already existing
         match entries.iter().position(|e| e.name == entry.name && e.version == entry.version) {
             Some(pos) => {
-                println!("{}", Paint::green(&format!("Updating {dep} in the lock file.")));
+                println!("{}", format!("Updating {dep} in the lock file.").green());
                 // replace the entry with the new data
                 entries[pos] = entry;
             }
             None => {
                 println!(
                     "{}",
-                    Paint::green(&format!(
-                        "Writing {}~{} to the lock file.",
-                        entry.name, entry.version
-                    ))
+                    format!("Writing {}~{} to the lock file.", entry.name, entry.version).green()
                 );
                 entries.push(entry);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     match soldeer::run(args.command) {
         Ok(_) => {}
         Err(err) => {
-            eprintln!("{}", Paint::red(&err.message))
+            eprintln!("{}", Paint::red(&err.to_string()))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 use clap::Parser;
 use soldeer::commands::Args;
-use yansi::Paint;
+use yansi::Paint as _;
 
 fn main() {
     let args = Args::parse();
     match soldeer::run(args.command) {
         Ok(_) => {}
         Err(err) => {
-            eprintln!("{}", Paint::red(&err.to_string()))
+            eprintln!("{}", err.to_string().red())
         }
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::Dependency,
+    config::{Dependency, HttpDependency},
     errors::{DownloadError, ProjectNotFound},
     utils::get_base_url,
 };
@@ -8,8 +8,8 @@ use reqwest::Client;
 use serde_derive::{Deserialize, Serialize};
 
 pub async fn get_dependency_url_remote(
-    dependency_name: &String,
-    dependency_version: &String,
+    dependency_name: &str,
+    dependency_version: &str,
 ) -> Result<String, DownloadError> {
     let url = format!(
         "{}/api/v1/revision-cli?project_name={}&revision={}",
@@ -90,12 +90,12 @@ pub async fn get_latest_forge_std_dependency() -> Result<Dependency, DownloadErr
                         cause: "Could not get the last forge dependency".to_string(),
                     });
                 }
-                return Ok(Dependency {
+                return Ok(Dependency::Http(HttpDependency {
                     name: dependency_name.to_string(),
                     version: revision.data[0].clone().version,
-                    url: revision.data[0].clone().url,
-                    hash: "".to_string(),
-                });
+                    url: Some(revision.data[0].clone().url),
+                    checksum: None,
+                }));
             }
         }
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -38,7 +38,7 @@ pub async fn get_dependency_url_remote(
 }
 
 //TODO clean this up and do error handling
-pub async fn get_project_id(dependency_name: &String) -> Result<String> {
+pub async fn get_project_id(dependency_name: &str) -> Result<String> {
     let url = format!("{}/api/v1/project?project_name={}", get_base_url(), dependency_name);
     let req = Client::new().get(url);
     let get_project_response = req.send().await;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::{Dependency, HttpDependency},
-    errors::{DownloadError, ProjectNotFound},
+    dependency_downloader::Result,
+    errors::DownloadError,
     utils::get_base_url,
 };
 use chrono::{DateTime, Utc};
@@ -10,7 +11,7 @@ use serde_derive::{Deserialize, Serialize};
 pub async fn get_dependency_url_remote(
     dependency_name: &str,
     dependency_version: &str,
-) -> Result<String, DownloadError> {
+) -> Result<String> {
     let url = format!(
         "{}/api/v1/revision-cli?project_name={}&revision={}",
         get_base_url(),
@@ -25,24 +26,19 @@ pub async fn get_dependency_url_remote(
             let revision = serde_json::from_str::<RevisionResponse>(&response_text);
             if let Ok(revision) = revision {
                 if revision.data.is_empty() {
-                    return Err(DownloadError {
-                        name: dependency_name.to_string(),
-                        version: dependency_version.to_string(),
-                        cause: "Could not get the dependency URL".to_string(),
-                    });
+                    return Err(DownloadError::URLNotFound(format!(
+                        "{dependency_name}~{dependency_version}"
+                    )));
                 }
                 return Ok(revision.data[0].clone().url);
             }
         }
     }
-    Err(DownloadError {
-        name: dependency_name.to_string(),
-        version: dependency_version.to_string(),
-        cause: "Could not get the dependency URL".to_string(),
-    })
+    Err(DownloadError::URLNotFound(format!("{dependency_name}~{dependency_version}")))
 }
+
 //TODO clean this up and do error handling
-pub async fn get_project_id(dependency_name: &String) -> Result<String, ProjectNotFound> {
+pub async fn get_project_id(dependency_name: &String) -> Result<String> {
     let url = format!("{}/api/v1/project?project_name={}", get_base_url(), dependency_name);
     let req = Client::new().get(url);
     let get_project_response = req.send().await;
@@ -58,19 +54,15 @@ pub async fn get_project_id(dependency_name: &String) -> Result<String, ProjectN
                     }
                 }
                 Err(_) => {
-                    return Err(ProjectNotFound {
-                        name: dependency_name.to_string(),
-                        cause: "Error from the server or check the internet connection."
-                            .to_string(),
-                    });
+                    return Err(DownloadError::ProjectNotFound(dependency_name.to_string()));
                 }
             }
         }
     }
-    Err(ProjectNotFound{name: dependency_name.to_string(), cause:"Project not found, please check the dependency name (project name) or create a new project on https://soldeer.xyz".to_string()})
+    Err(DownloadError::ProjectNotFound(dependency_name.to_string()))
 }
 
-pub async fn get_latest_forge_std_dependency() -> Result<Dependency, DownloadError> {
+pub async fn get_latest_forge_std_dependency() -> Result<Dependency> {
     let dependency_name = "forge-std";
     let url = format!(
         "{}/api/v1/revision?project_name={}&offset=0&limit=1",
@@ -84,11 +76,7 @@ pub async fn get_latest_forge_std_dependency() -> Result<Dependency, DownloadErr
             let revision = serde_json::from_str::<RevisionResponse>(&response_text);
             if let Ok(revision) = revision {
                 if revision.data.is_empty() {
-                    return Err(DownloadError {
-                        name: dependency_name.to_string(),
-                        version: "".to_string(),
-                        cause: "Could not get the last forge dependency".to_string(),
-                    });
+                    return Err(DownloadError::ForgeStdError);
                 }
                 return Ok(Dependency::Http(HttpDependency {
                     name: dependency_name.to_string(),
@@ -99,11 +87,7 @@ pub async fn get_latest_forge_std_dependency() -> Result<Dependency, DownloadErr
             }
         }
     }
-    Err(DownloadError {
-        name: dependency_name.to_string(),
-        version: "".to_string(),
-        cause: "Could not get the last forge dependency".to_string(),
-    })
+    Err(DownloadError::ForgeStdError)
 }
 
 #[allow(non_snake_case)]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -8,15 +8,12 @@ use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde_derive::{Deserialize, Serialize};
 
-pub async fn get_dependency_url_remote(
-    dependency_name: &str,
-    dependency_version: &str,
-) -> Result<String> {
+pub async fn get_dependency_url_remote(dependency: &Dependency) -> Result<String> {
     let url = format!(
         "{}/api/v1/revision-cli?project_name={}&revision={}",
         get_base_url(),
-        dependency_name,
-        dependency_version
+        dependency.name(),
+        dependency.version()
     );
     let req = Client::new().get(url);
 
@@ -26,15 +23,13 @@ pub async fn get_dependency_url_remote(
             let revision = serde_json::from_str::<RevisionResponse>(&response_text);
             if let Ok(revision) = revision {
                 if revision.data.is_empty() {
-                    return Err(DownloadError::URLNotFound(format!(
-                        "{dependency_name}~{dependency_version}"
-                    )));
+                    return Err(DownloadError::URLNotFound(dependency.to_string()));
                 }
                 return Ok(revision.data[0].clone().url);
             }
         }
     }
-    Err(DownloadError::URLNotFound(format!("{dependency_name}~{dependency_version}")))
+    Err(DownloadError::URLNotFound(dependency.to_string()))
 }
 
 //TODO clean this up and do error handling

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,10 +48,12 @@ pub fn read_file(path: impl AsRef<Path>) -> Result<Vec<u8>, std::io::Error> {
 
 /// Get the location where the token file is stored or read from
 ///
-/// The token file is stored in the home directory of the user in a hidden folder called `.soldeer`,
-/// or in the current working directory if the home directory cannot be found.
-/// For reading (e.g. when pushing to the registry), the path can be overridden by setting the
-/// `SOLDEER_LOGIN_FILE` environment variable.
+/// The token file is stored in the home directory of the user, or in the current working directory
+/// if the home cannot be found, in a hidden folder called `.soldeer`. The token file is called
+/// `.soldeer_login`.
+///
+/// For reading (e.g. when pushing to the registry), the path can be overridden by
+/// setting the `SOLDEER_LOGIN_FILE` environment variable.
 /// For login, the custom path will only be used if the file already exists.
 pub fn define_security_file_location() -> Result<PathBuf, std::io::Error> {
     let custom_security_file = if cfg!(test) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,7 +60,7 @@ pub fn define_security_file_location() -> Result<PathBuf, std::io::Error> {
     }
 
     // if home dir cannot be found, use the current working directory
-    let dir = home_dir().unwrap_or_else(|| get_current_working_dir());
+    let dir = home_dir().unwrap_or_else(get_current_working_dir);
     let security_directory = dir.join(".soldeer");
     if !security_directory.exists() {
         fs::create_dir(&security_directory)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
     io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
 };
-use yansi::Paint;
+use yansi::Paint as _;
 
 static GIT_SSH_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(?:git@github\.com|git@gitlab)").expect("git ssh regex should compile")
@@ -63,9 +63,7 @@ pub fn define_security_file_location() -> String {
         None => {
             println!(
                 "{}",
-                Paint::red(
-                    "HOME(linux) or %UserProfile%(Windows) path variable is not set, we can not determine the user's home directory. Please define this environment variable or define a custom path for the login file using the SOLDEER_LOGIN_FILE environment variable.",
-                    )
+                "HOME(linux) or %UserProfile%(Windows) path variable is not set, we can not determine the user's home directory. Please define this environment variable or define a custom path for the login file using the SOLDEER_LOGIN_FILE environment variable.".red()
             );
         }
     }
@@ -157,14 +155,16 @@ pub fn check_dotfiles_recursive(path: &Path) -> bool {
 
 // Function to prompt the user for confirmation
 pub fn prompt_user_for_confirmation() -> bool {
-    println!("{}", Paint::yellow(
-        "You are about to include some sensitive files in this version. Are you sure you want to continue?"
-    ));
-    println!("{}", Paint::cyan(
-        "If you are not sure what sensitive files, you can run the dry-run command to check what will be pushed."
-    ));
+    println!(
+        "{}",
+        "You are about to include some sensitive files in this version. Are you sure you want to continue?".yellow()
+    );
+    println!(
+        "{}",
+        "If you are not sure what sensitive files, you can run the dry-run command to check what will be pushed.".cyan()
+    );
 
-    print!("{}", Paint::green("Do you want to continue? (y/n): "));
+    print!("{}", "Do you want to continue? (y/n): ".green());
     std::io::stdout().flush().unwrap();
 
     let mut input = String::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -97,6 +97,9 @@ pub fn get_base_url() -> String {
 
 // Function to check for the presence of sensitive files or directories
 pub fn check_dotfiles(path: impl AsRef<Path>) -> bool {
+    if !path.as_ref().is_dir() {
+        return false;
+    }
     fs::read_dir(path)
         .unwrap()
         .map_while(Result::ok)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,6 +46,13 @@ pub fn read_file(path: impl AsRef<Path>) -> Result<Vec<u8>, std::io::Error> {
     Ok(buffer)
 }
 
+/// Get the location where the token file is stored or read from
+///
+/// The token file is stored in the home directory of the user in a hidden folder called `.soldeer`,
+/// or in the current working directory if the home directory cannot be found.
+/// For reading (e.g. when pushing to the registry), the path can be overridden by setting the
+/// `SOLDEER_LOGIN_FILE` environment variable.
+/// For login, the custom path will only be used if the file already exists.
 pub fn define_security_file_location() -> Result<PathBuf, std::io::Error> {
     let custom_security_file = if cfg!(test) {
         return Ok(PathBuf::from("./test_save_jwt"));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,18 +77,6 @@ pub fn define_security_file_location() -> String {
     String::from(security_file.to_str().unwrap())
 }
 
-pub fn remove_empty_lines(path: impl AsRef<Path>) -> Result<(), io::Error> {
-    let file = File::open(path.as_ref())?;
-    let reader = BufReader::new(file);
-    let lines: Vec<_> =
-        reader.lines().map_while(Result::ok).filter(|l| !l.trim().is_empty()).collect();
-    let mut file = File::create(path.as_ref())?;
-    for line in lines {
-        writeln!(file, "{}", line)?;
-    }
-    Ok(())
-}
-
 pub fn get_base_url() -> String {
     if cfg!(test) {
         env::var("base_url").unwrap_or("http://0.0.0.0".to_string())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -142,16 +142,16 @@ pub fn prompt_user_for_confirmation() -> bool {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum DependencyType {
+pub enum UrlType {
     Git,
     Http,
 }
 
-pub fn get_dependency_type(dependency_url: &str) -> DependencyType {
+pub fn get_url_type(dependency_url: &str) -> UrlType {
     if GIT_SSH_REGEX.is_match(dependency_url) || GIT_HTTPS_REGEX.is_match(dependency_url) {
-        return DependencyType::Git;
+        return UrlType::Git;
     }
-    DependencyType::Http
+    UrlType::Http
 }
 
 #[cfg(not(test))]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use simple_home_dir::home_dir;
 use std::{
     env,
     fs::{self, File},
-    io::{self, BufRead, BufReader, Read, Write},
+    io::{BufReader, Read, Write},
     path::{Path, PathBuf},
 };
 use yansi::Paint as _;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,8 @@ use std::{
 };
 use yansi::Paint as _;
 
+use crate::config::HttpDependency;
+
 static GIT_SSH_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(?:git@github\.com|git@gitlab)").expect("git ssh regex should compile")
 });
@@ -155,17 +157,17 @@ pub fn get_url_type(dependency_url: &str) -> UrlType {
 }
 
 #[cfg(not(test))]
-pub fn sha256_digest(dependency_name: &str, dependency_version: &str) -> String {
+pub fn sha256_digest(dependency: &HttpDependency) -> String {
     use crate::DEPENDENCY_DIR;
 
     let bytes = std::fs::read(
-        DEPENDENCY_DIR.join(format!("{}-{}.zip", dependency_name, dependency_version)),
+        DEPENDENCY_DIR.join(format!("{}-{}.zip", dependency.name, dependency.version)),
     )
     .unwrap(); // Vec<u8>
     sha256::digest(bytes)
 }
 
 #[cfg(test)]
-pub fn sha256_digest(_dependency_name: &str, _dependency_version: &str) -> String {
+pub fn sha256_digest(_dependency: &HttpDependency) -> String {
     "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
 }

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -16,7 +16,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use walkdir::WalkDir;
-use yansi::Paint;
+use yansi::Paint as _;
 use yash_fnmatch::{without_escape, Pattern};
 use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
@@ -31,7 +31,7 @@ pub async fn push_version(
     let file_name = root_directory_path.file_name().expect("path should have a last component");
     println!(
         "{}",
-        Paint::green(&format!("Pushing a dependency {}-{}:", dependency_name, dependency_version))
+        format!("Pushing a dependency {}-{}:", dependency_name, dependency_version).green()
     );
 
     let files_to_copy: Vec<PathBuf> = filter_files_to_copy(&root_directory_path);
@@ -221,7 +221,7 @@ async fn push_to_repo(
     let response = res.await.unwrap();
     match response.status() {
         StatusCode::OK => {
-            println!("{}", Paint::green("Success!"));
+            println!("{}", "Success!".green());
             Ok(())
         }
         StatusCode::NO_CONTENT => Err(PublishError::ProjectNotFound),

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -230,7 +230,7 @@ async fn push_to_repo(
             return Err(PushError {
                 name: (&dependency_name).to_string(),
                 version: (&dependency_version).to_string(),
-                cause: err.cause,
+                cause: err.to_string(),
             });
         }
     };

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -4,6 +4,7 @@ use crate::{
     remote::get_project_id,
     utils::{get_base_url, get_current_working_dir, read_file, read_file_to_string},
 };
+use regex::Regex;
 use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE},
     multipart::{Form, Part},
@@ -22,8 +23,8 @@ use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 pub type Result<T> = std::result::Result<T, PublishError>;
 
 pub async fn push_version(
-    dependency_name: &String,
-    dependency_version: &String,
+    dependency_name: &str,
+    dependency_version: &str,
     root_directory_path: PathBuf,
     dry_run: bool,
 ) -> Result<()> {
@@ -56,6 +57,14 @@ pub async fn push_version(
     // deleting zip archive
     let _ = remove_file(zip_archive);
 
+    Ok(())
+}
+
+pub fn validate_name(name: &str) -> Result<()> {
+    let regex = Regex::new(r"^[@|a-z0-9][a-z0-9-]*[a-z0-9]$").unwrap();
+    if !regex.is_match(name) {
+        return Err(PublishError::InvalidName);
+    }
     Ok(())
 }
 

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -263,7 +263,7 @@ async fn push_to_repo(
             return Err(PushError {
                 name: (&dependency_name).to_string(),
                 version: (&dependency_version).to_string(),
-                cause: err.cause,
+                cause: err.to_string(),
             });
         }
     };

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -1,6 +1,6 @@
 use crate::{
     auth::get_token,
-    errors::PushError,
+    errors::{AuthError, PublishError},
     remote::get_project_id,
     utils::{get_base_url, get_current_working_dir, read_file, read_file_to_string},
 };
@@ -19,33 +19,23 @@ use yansi::Paint;
 use yash_fnmatch::{without_escape, Pattern};
 use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
-#[derive(Clone, Debug)]
-struct FilePair {
-    name: String,
-    path: String,
-}
+pub type Result<T> = std::result::Result<T, PublishError>;
 
 pub async fn push_version(
     dependency_name: &String,
     dependency_version: &String,
     root_directory_path: PathBuf,
     dry_run: bool,
-) -> Result<(), PushError> {
+) -> Result<()> {
     let file_name = root_directory_path.file_name().expect("path should have a last component");
     println!(
         "{}",
         Paint::green(&format!("Pushing a dependency {}-{}:", dependency_name, dependency_version))
     );
 
-    let files_to_copy: Vec<FilePair> = filter_files_to_copy(&root_directory_path);
+    let files_to_copy: Vec<PathBuf> = filter_files_to_copy(&root_directory_path);
 
-    let zip_archive = match zip_file(
-        dependency_name,
-        dependency_version,
-        &root_directory_path,
-        &files_to_copy,
-        file_name,
-    ) {
+    let zip_archive = match zip_file(&root_directory_path, &files_to_copy, file_name) {
         Ok(zip) => zip,
         Err(err) => {
             return Err(err);
@@ -70,87 +60,52 @@ pub async fn push_version(
 }
 
 fn zip_file(
-    dependency_name: &String,
-    dependency_version: &String,
     root_directory_path: &Path,
-    files_to_copy: &Vec<FilePair>,
+    files_to_copy: &Vec<PathBuf>,
     file_name: impl Into<PathBuf>,
-) -> Result<PathBuf, PushError> {
-    let root_dir_as_string = root_directory_path.to_str().unwrap();
+) -> Result<PathBuf> {
     let mut file_name: PathBuf = file_name.into();
     file_name.set_extension("zip");
     let zip_file_path = root_directory_path.join(file_name);
-    let file = File::create(zip_file_path.to_str().unwrap()).unwrap();
+    let file = File::create(&zip_file_path).unwrap();
     let mut zip = ZipWriter::new(file);
     let options = SimpleFileOptions::default().compression_method(CompressionMethod::DEFLATE);
     if files_to_copy.is_empty() {
-        return Err(PushError {
-            name: dependency_name.to_string(),
-            version: dependency_version.to_string(),
-            cause: "No files to push".to_string(),
-        });
+        return Err(PublishError::NoFiles);
     }
 
     for file_path in files_to_copy {
-        let file_to_copy = File::open(file_path.path.clone()).unwrap();
-        let file_to_copy_name = file_path.name.clone();
-        let path = Path::new(&file_path.path);
+        let file_to_copy = File::open(file_path.clone())
+            .map_err(|e| PublishError::IOError { path: file_path.clone(), source: e })?;
+        let path = Path::new(&file_path);
         let mut buffer = Vec::new();
 
         // This is the relative path, we basically get the relative path to the target folder that
         // we want to push and zip that as a name so we won't screw up the file/dir
         // hierarchy in the zip file.
-        let relative_file_path = file_path.path.to_string().replace(root_dir_as_string, "");
+        let relative_file_path = file_path.strip_prefix(root_directory_path)?;
 
         // Write file or directory explicitly
         // Some unzip tools unzip files with directory paths correctly, some do not!
         if path.is_file() {
-            match zip.start_file(relative_file_path, options) {
-                Ok(_) => {}
-                Err(err) => {
-                    return Err(PushError {
-                        name: dependency_name.to_string(),
-                        version: dependency_version.to_string(),
-                        cause: format!("Zipping failed. Could not start to zip: {}", err),
-                    });
-                }
-            }
-            match io::copy(&mut file_to_copy.take(u64::MAX), &mut buffer) {
-                Ok(_) => {}
-                Err(err) => {
-                    return Err(PushError {
-                        name: dependency_name.to_string(),
-                        version: dependency_version.to_string(),
-                        cause: format!(
-                            "Zipping failed, could not read file {} because of the error {}",
-                            file_to_copy_name, err
-                        ),
-                    });
-                }
-            }
-            match zip.write_all(&buffer) {
-                Ok(_) => {}
-                Err(err) => {
-                    return Err(PushError {
-                        name: dependency_name.to_string(),
-                        version: dependency_version.to_string(),
-                        cause: format!("Zipping failed. Could not write to zip: {}", err),
-                    });
-                }
-            }
-        } else if !path.as_os_str().is_empty() {
-            let _ = zip.add_directory(&file_path.path, options);
+            zip.start_file(relative_file_path.to_string_lossy(), options)?;
+            io::copy(&mut file_to_copy.take(u64::MAX), &mut buffer)
+                .map_err(|e| PublishError::IOError { path: file_path.clone(), source: e })?;
+            zip.write_all(&buffer)
+                .map_err(|e| PublishError::IOError { path: zip_file_path.clone(), source: e })?;
+        } else if path.is_dir() {
+            let _ = zip.add_directory(file_path.to_string_lossy(), options);
         }
     }
     let _ = zip.finish();
     Ok(zip_file_path)
 }
 
-fn filter_files_to_copy(root_directory_path: &Path) -> Vec<FilePair> {
+fn filter_files_to_copy(root_directory_path: &Path) -> Vec<PathBuf> {
     let ignore_files: Vec<String> = read_ignore_file();
 
     let root_directory: &str = &(root_directory_path.to_str().unwrap().to_owned() + "/");
-    let mut files_to_copy: Vec<FilePair> = Vec::new();
+    let mut files_to_copy: Vec<PathBuf> = Vec::new();
     for entry in WalkDir::new(root_directory).into_iter().filter_map(|e| e.ok()) {
         let is_dir = entry.path().is_dir();
         let file_path: String = entry.path().to_str().unwrap().to_string();
@@ -171,15 +126,7 @@ fn filter_files_to_copy(root_directory_path: &Path) -> Vec<FilePair> {
             continue;
         }
 
-        files_to_copy.push(FilePair {
-            name: entry
-                .path()
-                .file_name()
-                .expect("path should have a last component")
-                .to_string_lossy()
-                .into_owned(),
-            path: entry.path().to_str().unwrap().to_string(),
-        });
+        files_to_copy.push(entry.path().to_path_buf());
     }
     files_to_copy
 }
@@ -221,19 +168,10 @@ fn escape_lines(lines: Vec<&str>) -> Vec<String> {
 
 async fn push_to_repo(
     zip_file: &Path,
-    dependency_name: &String,
-    dependency_version: &String,
-) -> Result<(), PushError> {
-    let token = match get_token() {
-        Ok(result) => result,
-        Err(err) => {
-            return Err(PushError {
-                name: (&dependency_name).to_string(),
-                version: (&dependency_version).to_string(),
-                cause: err.to_string(),
-            });
-        }
-    };
+    dependency_name: &str,
+    dependency_version: &str,
+) -> Result<()> {
+    let token = get_token()?;
     let client = Client::new();
 
     let url = format!("{}/api/v1/revision/upload", get_base_url());
@@ -257,20 +195,11 @@ async fn push_to_repo(
     // set the mime as app zip
     part = part.mime_str("application/zip").expect("Could not set mime type");
 
-    let project_id = match get_project_id(dependency_name).await {
-        Ok(id) => id,
-        Err(err) => {
-            return Err(PushError {
-                name: (&dependency_name).to_string(),
-                version: (&dependency_version).to_string(),
-                cause: err.to_string(),
-            });
-        }
-    };
+    let project_id = get_project_id(dependency_name).await?;
 
     let form = Form::new()
         .text("project_id", project_id)
-        .text("revision", dependency_version.clone())
+        .text("revision", dependency_version.to_string())
         .part("zip_name", part);
 
     headers.insert(
@@ -282,44 +211,19 @@ async fn push_to_repo(
 
     let response = res.await.unwrap();
     match response.status() {
-        StatusCode::OK => println!("{}", Paint::green("Success!")),
-        StatusCode::NO_CONTENT => {
-            return Err(PushError {
-                name: (&dependency_name).to_string(),
-                version: (&dependency_version).to_string(),
-                cause: "Project not found. Make sure you send the right dependency name.\nThe dependency name is the project name you created on https://soldeer.xyz".to_string(),
-            });
+        StatusCode::OK => {
+            println!("{}", Paint::green("Success!"));
+            Ok(())
         }
-        StatusCode::ALREADY_REPORTED => {
-            return Err(PushError {
-                name: (&dependency_name).to_string(),
-                version: (&dependency_version).to_string(),
-                cause: "Dependency already exists".to_string(),
-            });
+        StatusCode::NO_CONTENT => Err(PublishError::ProjectNotFound),
+        StatusCode::ALREADY_REPORTED => Err(PublishError::AlreadyExists),
+        StatusCode::UNAUTHORIZED => Err(PublishError::AuthError(AuthError::InvalidCredentials)),
+        StatusCode::PAYLOAD_TOO_LARGE => Err(PublishError::PayloadTooLarge),
+        s if s.is_server_error() || s.is_client_error() => {
+            Err(PublishError::HttpError(response.error_for_status().unwrap_err()))
         }
-        StatusCode::UNAUTHORIZED => {
-            return Err(PushError {
-                name: (&dependency_name).to_string(),
-                version: (&dependency_version).to_string(),
-                cause: "Unauthorized. Please login".to_string(),
-            });
-        }
-        StatusCode::PAYLOAD_TOO_LARGE => {
-            return Err(PushError {
-                name: (&dependency_name).to_string(),
-                version: (&dependency_version).to_string(),
-                cause: "The package is too big, it has over 50 MB".to_string(),
-            });
-        }
-        _ => {
-            return Err(PushError {
-                name: (&dependency_name).to_string(),
-                version: (&dependency_version).to_string(),
-                cause: format!("The server returned an unexpected error {:?}", response.status()),
-            });
-        }
+        _ => Err(PublishError::UnknownError),
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -424,7 +328,7 @@ mod tests {
         let result = filter_files_to_copy(&target_dir);
         assert_eq!(filtered_files.len(), result.len());
         let file = Path::new(&filtered_files[0]);
-        assert_eq!(file.file_name().unwrap().to_string_lossy(), result[0].name);
+        assert_eq!(file, result[0]);
 
         let _ = remove_file(gitignore);
         let _ = remove_dir_all(target_dir);
@@ -466,16 +370,12 @@ mod tests {
         // --- --- --- --- zip <= ignored
         // --- --- --- --- toml <= ignored
 
-        let random_dir = PathBuf::from(create_random_directory(&target_dir, "".to_string()));
-        let broadcast_dir =
-            PathBuf::from(create_random_directory(&target_dir, "broadcast".to_string()));
+        let random_dir = create_random_directory(&target_dir, "".to_string());
+        let broadcast_dir = create_random_directory(&target_dir, "broadcast".to_string());
 
-        let the_31337_dir =
-            PathBuf::from(create_random_directory(&broadcast_dir, "31337".to_string()));
-        let random_dir_in_broadcast =
-            PathBuf::from(create_random_directory(&broadcast_dir, "".to_string()));
-        let dry_run_dir =
-            PathBuf::from(create_random_directory(&random_dir_in_broadcast, "dry_run".to_string()));
+        let the_31337_dir = create_random_directory(&broadcast_dir, "31337".to_string());
+        let random_dir_in_broadcast = create_random_directory(&broadcast_dir, "".to_string());
+        let dry_run_dir = create_random_directory(&random_dir_in_broadcast, "dry_run".to_string());
 
         ignored_files.push(create_random_file(&random_dir, "toml".to_string()));
         filtered_files.push(create_random_file(&random_dir, "zip".to_string()));
@@ -504,11 +404,11 @@ mod tests {
 
         // for each result we just just to see if a file (not a dir) is in the filtered results
         for res in result {
-            if PathBuf::from(&res.path).is_dir() {
+            if PathBuf::from(&res).is_dir() {
                 continue;
             }
 
-            assert!(filtered_files.contains(&res.path));
+            assert!(filtered_files.contains(&res));
         }
 
         let _ = remove_file(gitignore);
@@ -534,25 +434,19 @@ mod tests {
         // --- random_file_1.txt
         let random_dir_1 = create_random_directory(&target_dir, "".to_string());
         let random_dir_2 = create_random_directory(Path::new(&random_dir_1), "".to_string());
-        let random_file_1 = create_random_file(&target_dir, ".txt".to_string());
-        let random_file_2 = create_random_file(Path::new(&random_dir_1), ".txt".to_string());
-        let random_file_3 = create_random_file(Path::new(&random_dir_2), ".txt".to_string());
+        let random_file_1 = create_random_file(&target_dir, "txt".to_string());
+        let random_file_2 = create_random_file(Path::new(&random_dir_1), "txt".to_string());
+        let random_file_3 = create_random_file(Path::new(&random_dir_2), "txt".to_string());
 
-        let dep_name = "test_dep".to_string();
-        let dep_version = "1.1".to_string();
-        let files_to_copy: Vec<FilePair> = vec![
-            FilePair { name: "random_file_1".to_string(), path: random_file_1.clone() },
-            FilePair { name: "random_file_1".to_string(), path: random_file_3.clone() },
-            FilePair { name: "random_file_1".to_string(), path: random_file_2.clone() },
-        ];
-        let result =
-            match zip_file(&dep_name, &dep_version, &target_dir, &files_to_copy, "test_zip") {
-                Ok(r) => r,
-                Err(_) => {
-                    assert_eq!("Invalid State", "");
-                    return;
-                }
-            };
+        let files_to_copy: Vec<PathBuf> =
+            vec![random_file_1.clone(), random_file_3.clone(), random_file_2.clone()];
+        let result = match zip_file(&target_dir, &files_to_copy, "test_zip") {
+            Ok(r) => r,
+            Err(_) => {
+                assert_eq!("Invalid State", "");
+                return;
+            }
+        };
 
         // unzipping for checks
         let archive = read_file(result).unwrap();
@@ -563,9 +457,13 @@ mod tests {
             }
         }
 
-        let random_file_1_unzipped = random_file_1.replace("test_zip", "test_unzip");
-        let random_file_2_unzipped = random_file_2.replace("test_zip", "test_unzip");
-        let random_file_3_unzipped = random_file_3.replace("test_zip", "test_unzip");
+        let mut random_file_1_unzipped = target_dir_unzip.clone();
+        random_file_1_unzipped.push(random_file_1.strip_prefix(&target_dir).unwrap());
+        let mut random_file_2_unzipped = target_dir_unzip.clone();
+        random_file_2_unzipped.push(random_file_2.strip_prefix(&target_dir).unwrap());
+        let mut random_file_3_unzipped = target_dir_unzip.clone();
+        random_file_3_unzipped.push(random_file_3.strip_prefix(&target_dir).unwrap());
+        println!("{random_file_3_unzipped:?}");
 
         assert!(Path::new(&random_file_1_unzipped).exists());
         assert!(Path::new(&random_file_2_unzipped).exists());
@@ -595,7 +493,7 @@ mod tests {
         }
     }
 
-    fn create_random_file(target_dir: &Path, extension: String) -> String {
+    fn create_random_file(target_dir: &Path, extension: String) -> PathBuf {
         let s: String =
             rand::thread_rng().sample_iter(&Alphanumeric).take(7).map(char::from).collect();
         let target = target_dir.join(format!("random{}.{}", s, extension));
@@ -604,20 +502,20 @@ mod tests {
         if let Err(e) = write!(file, "this is a test file") {
             eprintln!("Couldn't write to the config file: {}", e);
         }
-        String::from(target.to_str().unwrap())
+        target
     }
-    fn create_random_directory(target_dir: &Path, name: String) -> String {
+    fn create_random_directory(target_dir: &Path, name: String) -> PathBuf {
         let s: String =
             rand::thread_rng().sample_iter(&Alphanumeric).take(7).map(char::from).collect();
 
         if name.is_empty() {
             let target = target_dir.join(format!("random{}", s));
             let _ = create_dir_all(&target);
-            return String::from(target.to_str().unwrap());
+            target
         } else {
             let target = target_dir.join(name);
             let _ = create_dir_all(&target);
-            return String::from(target.to_str().unwrap());
+            target
         }
     }
 }

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -2,7 +2,6 @@ use clap::Parser as _;
 use serial_test::serial;
 use soldeer::{
     commands::{Args, Install, Subcommands},
-    errors::SoldeerError,
     DEPENDENCY_DIR, LOCK_FILE,
 };
 use std::{

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -1,6 +1,7 @@
+use clap::Parser as _;
 use serial_test::serial;
 use soldeer::{
-    commands::{Install, Subcommands},
+    commands::{Args, Install, Subcommands},
     errors::SoldeerError,
     DEPENDENCY_DIR, LOCK_FILE,
 };
@@ -121,25 +122,7 @@ contract TestSoldeer is Test {
 #[test]
 #[serial]
 fn soldeer_install_invalid_dependency() {
-    let command = Subcommands::Install(Install {
-        dependency: Some("forge-std".to_string()),
-        remote_url: None,
-        rev: None,
-    });
-
-    match soldeer::run(command) {
-        Ok(_) => {
-            assert_eq!("Invalid State", "")
-        }
-        Err(err) => {
-            assert_eq!(
-                err,
-                SoldeerError{
-                   message: "Dependency forge-std does not specify a version.\nThe format should be [DEPENDENCY]~[VERSION]".to_string()
-                }
-            );
-        }
-    }
+    assert!(Args::try_parse_from(["soldeer", "install", "forge-std"]).is_err());
 
     let path_dependency = DEPENDENCY_DIR.join("forge-std");
     let path_zip = DEPENDENCY_DIR.join("forge-std.zip");

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -24,7 +24,7 @@ fn soldeer_install_valid_dependency() {
         dependency: Some("forge-std~1.8.2".to_string()),
         remote_url: None,
         rev: None,
-        reg_remappings: None,
+        regenerate_remappings: None,
     });
 
     match soldeer::run(command) {

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -24,6 +24,7 @@ fn soldeer_install_valid_dependency() {
         dependency: Some("forge-std~1.8.2".to_string()),
         remote_url: None,
         rev: None,
+        reg_remappings: None,
     });
 
     match soldeer::run(command) {

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -24,7 +24,7 @@ fn soldeer_install_valid_dependency() {
         dependency: Some("forge-std~1.8.2".to_string()),
         remote_url: None,
         rev: None,
-        regenerate_remappings: Some(false),
+        regenerate_remappings: false,
     });
 
     match soldeer::run(command) {


### PR DESCRIPTION
Big refactor to adopt idiomatic Rust patterns and improve the existing public API.

## Breaking Changes
### Config file
The config file (whichever has a `[dependencies]` table between `foundry.toml` and `soldeer.toml`) now has a `[soldeer]` section with the following format and defaults:

```toml
[soldeer]
# whether soldeer manages remappings
remappings_generated = true

# whether soldeer re-generates all remappings when installing, updating or uninstalling deps
remappings_regenerate = false

# whether to suffix the remapping with the version: `name-a.b.c`
remappings_version = true

# a prefix to add to the remappings ("@" would give `@name`)
remappings_prefix = ""

# where to store the remappings ("txt" for `remappings.txt` or "config" for `foundry.toml`)
# ignored when `soldeer.toml` is used as config (uses `remappings.txt`)
remappings_location = "txt"
```

### Remappings

Remappings are now properly managed by Soldeer if desired. They can be updated inside the `foundry.toml` file if that file is also used for `[dependencies]`.

Remappings in the `[profile.default]` are always managed if `remappings_generated = true`. Other profiles only get managed if they already contain a `remappings` array.

If `remappings_regenerate = false`, then existing remappings are not modified by Soldeer, unless a dependency is removed. This allows for remappings customization.

### Auth
- fallible functions now return an `AuthError`
### Commands
- subcommand `VersionDryRun` renamed to `Version`
- flag `clean` for subcommand `Init` is now a `bool`
- flag `dry_run` for subcommand `Push` is now a `bool`
- flag `skip_warnings` for subcommand `Push` is now a `bool`
### Config
- fallible functions now return a `ConfigError`
- `Dependency` is now an enum with variants `Http` and `Git`
- `read_config` renamed to `read_config_deps` and takes a `AsRef<Path>` parameter
- `define_config_file` renamed to `get_config_path`
- `add_to_config`: removed params `custom_url` and `via_git`, param `config_file` now named `config_path` of type `AsRef<Path>`
- `remappings` replaced by `remappings_txt` and `remappings_foundry`
- `get_foundry_setup` replaced with `read_soldeer_config` which returns a `SoldeerConfig` struct
- `delete_config` now takes a `AsRef<Path>` second param
### Dependency Downloader
- fallible functions now return a `DownloadError`
- `download_dependencies` returns a `Vec<DownloadResult>`
- `download_dependency` has a second argument `skip_folder_check` of type `bool` and returns a `DownloadResult`
- `unzip_dependency` now takes a single `&HttpDependency` parameter
- `download_via_git` now takes a `&GitDependency`
- `download_via_http` now takes a `IntoUrl` first param, and `&HttpDependency` second param
### Janitor
- fallible functions now return a `JanitorError`
- `cleanup_dependency` now takes a `full: bool` as second parameter which removes the entire `dependencies` folder and lockfile when true
### Soldeer (lib)
- `run` returns a `SoldeerError` in case of issues
- re-export `errors::SoldeerError`
- re-export `commands::Subcommands`
### Lock
- fallible functions now return a `LockError`
### Remote
- fallible functions now return a `DownloadError`
- `get_dependency_url_remote` now takes a single `&Dependency` parameter
- `get_project_id` now accepts `&str` as input
### Utils
- `define_security_file_location` now returns a `Result<PathBuf, std::io::Error>`
- `check_dotfiles` now accepts `AsRef<Path>` as input
- `check_dotfiles_recursive` now accepts `AsRef<Path>` as input
- `get_download_tunnel` replaced with `get_url_type`
- `sha256_digest`now takes a single `&HttpDependency` as input
### Versioning
- fallible functions now return a `PublishError`
- `push_version` takes `&str` as first and second parameters

Closes #106
Closes #107
Closes #117
Closes #119
Closes #121