### PR TITLE
feat: add integrity checksum to lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,9 +1653,7 @@ dependencies = [
  "tokio",
  "toml_edit",
  "uuid",
- "walkdir",
  "yansi",
- "yash-fnmatch",
  "zip 2.1.6",
  "zip-extract",
 ]
@@ -2247,17 +2245,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yash-fnmatch"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697c20b479d2e6419e9a073bfdd20e90cbd8540d6c683ee46712e13de650e54f"
-dependencies = [
- "regex",
- "regex-syntax",
- "thiserror",
-]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serial_test",
+ "sha2",
  "sha256",
  "simple-home-dir",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +317,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +351,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -563,6 +605,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +834,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +915,12 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "lock_api"
@@ -935,6 +1012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1113,6 +1191,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1299,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1590,9 +1693,11 @@ version = "0.2.19"
 dependencies = [
  "chrono",
  "clap",
+ "const-hex",
  "email-address-parser",
  "env_logger",
  "futures",
+ "ignore",
  "mockito",
  "once_cell",
  "rand",
@@ -1839,6 +1944,12 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,17 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,19 +1618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha256"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18278f6a914fa3070aa316493f7d2ddfb9ac86ebc06fa3b83bffda487e9065b0"
-dependencies = [
- "async-trait",
- "bytes",
- "hex",
- "sha2",
- "tokio",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,7 +1685,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
- "sha256",
  "simple-home-dir",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,7 @@ tokio = { version = "1.38.0", features = [
 ] }
 toml_edit = { version = "0.22.15", features = ["serde"] }
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
-walkdir = "2.5.0"
 yansi = "1.0.1"
-yash-fnmatch = "1.1.1"
 zip = { version = "2.1.3", default-features = false, features = ["deflate"] }
 zip-extract = "0.1.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ version = "0.2.19"
 
 [dependencies]
 chrono = { version = "0.4.38", default-features = false, features = [
-  "std",
-  "serde",
+    "std",
+    "serde",
 ] }
 clap = { version = "4.5.9", features = ["derive"] }
 email-address-parser = "2.0.0"
@@ -23,15 +23,16 @@ futures = "0.3.30"
 once_cell = "1.19"
 regex = "1.10.5"
 reqwest = { version = "0.12.5", features = [
-  "blocking",
-  "json",
-  "multipart",
-  "stream",
+    "blocking",
+    "json",
+    "multipart",
+    "stream",
 ], default-features = false }
 rpassword = "7.3.1"
 serde = "1.0.204"
 serde_derive = "1.0.204"
 serde_json = "1.0.120"
+sha2 = "0.10.8"
 sha256 = "1.5.0"
 simple-home-dir = "0.4.0"
 thiserror = "1.0.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ sanitize-filename = "0.5.0"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 sha2 = "0.10.8"
-sha256 = "1.5.0"
 simple-home-dir = "0.4.0"
 thiserror = "1.0.63"
 tokio = { version = "1.38.0", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ chrono = { version = "0.4.38", default-features = false, features = [
     "serde",
 ] }
 clap = { version = "4.5.9", features = ["derive"] }
+const-hex = "1.12.0"
 email-address-parser = "2.0.0"
 futures = "0.3.30"
+ignore = { version = "0.4.22", features = ["simd-accel"] }
 once_cell = "1.19"
 regex = "1.10.5"
 reqwest = { version = "0.12.5", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,11 @@ serde_json = "1.0.120"
 sha2 = "0.10.8"
 simple-home-dir = "0.4.0"
 thiserror = "1.0.63"
-tokio = { version = "1.38.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.38.0", features = [
+    "rt-multi-thread",
+    "macros",
+    "io-util",
+] }
 toml_edit = { version = "0.22.15", features = ["serde"] }
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 walkdir = "2.5.0"

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -18,7 +18,7 @@ use yansi::Paint as _;
 
 pub type Result<T> = std::result::Result<T, DownloadError>;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct IntegrityChecksum(pub String);
 
 impl<T> From<T> for IntegrityChecksum

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -2,7 +2,7 @@ use crate::{
     config::{Dependency, GitDependency, HttpDependency},
     errors::DownloadError,
     remote::get_dependency_url_remote,
-    utils::{read_file, sanitize_dependency_name, sha256_digest},
+    utils::{hash_folder, read_file, sanitize_dependency_name, sha256_digest},
     DEPENDENCY_DIR,
 };
 use reqwest::IntoUrl;
@@ -19,7 +19,13 @@ use yansi::Paint as _;
 pub type Result<T> = std::result::Result<T, DownloadError>;
 
 #[derive(Debug, Clone, Default)]
-pub struct IntegrityChecksum(String);
+pub struct IntegrityChecksum(pub String);
+
+impl From<IntegrityChecksum> for String {
+    fn from(value: IntegrityChecksum) -> Self {
+        value.0
+    }
+}
 
 pub async fn download_dependencies(
     dependencies: &[Dependency],
@@ -56,12 +62,12 @@ pub async fn download_dependencies(
 }
 
 // un-zip-ing dependencies to dependencies folder
-pub fn unzip_dependencies(dependencies: &[Dependency]) -> Result<Vec<IntegrityChecksum>> {
+pub fn unzip_dependencies(dependencies: &[Dependency]) -> Result<Vec<Option<IntegrityChecksum>>> {
     let res: Vec<_> = dependencies
         .iter()
-        .filter_map(|d| match d {
-            Dependency::Http(dep) => Some(unzip_dependency(dep)),
-            _ => None,
+        .map(|d| match d {
+            Dependency::Http(dep) => unzip_dependency(dep).map(Some),
+            _ => Ok(None),
         })
         .collect::<Result<Vec<_>>>()?;
     Ok(res)
@@ -115,14 +121,15 @@ pub fn unzip_dependency(dependency: &HttpDependency) -> Result<IntegrityChecksum
     let file_name =
         sanitize_dependency_name(&format!("{}-{}", dependency.name, dependency.version));
     let target_name = format!("{}/", file_name);
-    let current_dir = DEPENDENCY_DIR.join(format!("{file_name}.zip"));
-    let target = DEPENDENCY_DIR.join(target_name);
-    let archive = read_file(current_dir).unwrap();
+    let zip_path = DEPENDENCY_DIR.join(format!("{file_name}.zip"));
+    let target_dir = DEPENDENCY_DIR.join(target_name);
+    let zip_contents = read_file(&zip_path).unwrap();
 
-    zip_extract::extract(Cursor::new(archive), &target, true)?;
+    zip_extract::extract(Cursor::new(zip_contents), &target_dir, true)?;
     println!("{}", format!("The dependency {dependency} was unzipped!").green());
 
-    Ok(IntegrityChecksum::default())
+    hash_folder(&target_dir, zip_path)
+        .map_err(|e| DownloadError::IOError { path: target_dir, source: e })
 }
 
 pub fn clean_dependency_directory() {

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -128,7 +128,7 @@ pub fn unzip_dependency(dependency: &HttpDependency) -> Result<IntegrityChecksum
     zip_extract::extract(Cursor::new(zip_contents), &target_dir, true)?;
     println!("{}", format!("The dependency {dependency} was unzipped!").green());
 
-    hash_folder(&target_dir, zip_path)
+    hash_folder(&target_dir, Some(zip_path))
         .map_err(|e| DownloadError::IOError { path: target_dir, source: e })
 }
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -261,12 +261,7 @@ integrity = "deadbeef"
             checksum: Some("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string())
         });
         let dependencies = vec![dependency.clone()];
-        write_lock(
-            &dependencies,
-            &[Some(IntegrityChecksum("deadbeef".to_string()))],
-            LockWriteMode::Append,
-        )
-        .unwrap();
+        write_lock(&dependencies, &[Some("deadbeef".into())], LockWriteMode::Append).unwrap();
         assert!(matches!(lock_check(&dependency, true), Err(LockError::DependencyInstalled(_))));
 
         let contents = read_file_to_string(lock_file);
@@ -297,12 +292,7 @@ integrity = "deadbeef"
             checksum: Some("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string())
         });
         dependencies.push(dependency.clone());
-        write_lock(
-            &dependencies,
-            &[Some(IntegrityChecksum("deadbeef".to_string()))],
-            LockWriteMode::Append,
-        )
-        .unwrap();
+        write_lock(&dependencies, &[Some("deadbeef".into())], LockWriteMode::Append).unwrap();
         let contents = read_file_to_string(lock_file);
 
         assert_eq!(
@@ -375,10 +365,7 @@ integrity = "deadbeef"
         let dependencies = vec![dependency.clone(), dependency2.clone()];
         write_lock(
             &dependencies,
-            &[
-                Some(IntegrityChecksum("deadbeef".to_string())),
-                Some(IntegrityChecksum("deadbeef".to_string())),
-            ],
+            &[Some("deadbeef".into()), Some("deadbeef".into())],
             LockWriteMode::Append,
         )
         .unwrap();
@@ -415,12 +402,7 @@ integrity = "deadbeef"
         });
 
         let dependencies = vec![dependency.clone()];
-        write_lock(
-            &dependencies,
-            &[Some(IntegrityChecksum("deadbeef".to_string()))],
-            LockWriteMode::Append,
-        )
-        .unwrap();
+        write_lock(&dependencies, &[Some("deadbeef".into())], LockWriteMode::Append).unwrap();
 
         match remove_lock(&Dependency::Http(HttpDependency {
             name: "non-existent".to_string(),

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -95,7 +95,7 @@ pub fn write_lock(
                 &dep.version,
                 dep.url.as_ref().unwrap(),
                 dep.checksum.as_ref().unwrap(),
-                integrity.clone().map(Into::into),
+                integrity.clone().map(|c| c.to_string()),
             ),
             Dependency::Git(dep) => {
                 LockEntry::new(&dep.name, &dep.version, &dep.git, dep.rev.as_ref().unwrap(), None)

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::Dependency,
+    dependency_downloader::IntegrityChecksum,
     errors::LockError,
     utils::{get_current_working_dir, read_file_to_string},
     LOCK_FILE,
@@ -12,11 +13,13 @@ pub type Result<T> = std::result::Result<T, LockError>;
 
 // Top level struct to hold the TOML data.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub struct LockEntry {
     name: String,
     version: String,
     source: String,
     checksum: String,
+    integrity: Option<String>,
 }
 
 impl LockEntry {
@@ -26,12 +29,14 @@ impl LockEntry {
         version: impl Into<String>,
         source: impl Into<String>,
         checksum: impl Into<String>,
+        integrity: Option<String>,
     ) -> Self {
         LockEntry {
             name: name.into(),
             version: version.into(),
             source: source.into(),
             checksum: checksum.into(),
+            integrity,
         }
     }
 }
@@ -63,7 +68,11 @@ pub enum LockWriteMode {
     Append,
 }
 
-pub fn write_lock(dependencies: &[Dependency], mode: LockWriteMode) -> Result<()> {
+pub fn write_lock(
+    dependencies: &[Dependency],
+    integrity_checksums: &[Option<IntegrityChecksum>],
+    mode: LockWriteMode,
+) -> Result<()> {
     let lock_file: PathBuf = if cfg!(test) {
         get_current_working_dir().join("test").join("soldeer.lock")
     } else {
@@ -79,16 +88,17 @@ pub fn write_lock(dependencies: &[Dependency], mode: LockWriteMode) -> Result<()
     }
 
     let mut entries = read_lock()?;
-    for dep in dependencies {
+    for (dep, integrity) in dependencies.iter().zip(integrity_checksums.iter()) {
         let entry = match dep {
             Dependency::Http(dep) => LockEntry::new(
                 &dep.name,
                 &dep.version,
                 dep.url.as_ref().unwrap(),
                 dep.checksum.as_ref().unwrap(),
+                integrity.clone().map(Into::into),
             ),
             Dependency::Git(dep) => {
-                LockEntry::new(&dep.name, &dep.version, &dep.git, dep.rev.as_ref().unwrap())
+                LockEntry::new(&dep.name, &dep.version, &dep.git, dep.rev.as_ref().unwrap(), None)
             }
         };
         // check for entry already existing
@@ -198,12 +208,14 @@ name = "@openzeppelin-contracts"
 version = "2.3.0"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip"
 checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
+integrity = "deadbeef"
 
 [[dependencies]]
 name = "@prb-test"
 version = "0.6.5"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@prb-test~0.6.5.zip"
 checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+integrity = "deadbeef"
 "#;
         File::create(lock_file).unwrap().write_all(lock_contents.as_bytes()).unwrap();
     }
@@ -249,7 +261,12 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             checksum: Some("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string())
         });
         let dependencies = vec![dependency.clone()];
-        write_lock(&dependencies, LockWriteMode::Append).unwrap();
+        write_lock(
+            &dependencies,
+            &[Some(IntegrityChecksum("deadbeef".to_string()))],
+            LockWriteMode::Append,
+        )
+        .unwrap();
         assert!(matches!(lock_check(&dependency, true), Err(LockError::DependencyInstalled(_))));
 
         let contents = read_file_to_string(lock_file);
@@ -261,6 +278,7 @@ name = "@openzeppelin-contracts"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
 checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+integrity = "deadbeef"
 "#
         );
         assert!(matches!(lock_check(&dependency, true), Err(LockError::DependencyInstalled(_))));
@@ -279,7 +297,12 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             checksum: Some("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string())
         });
         dependencies.push(dependency.clone());
-        write_lock(&dependencies, LockWriteMode::Append).unwrap();
+        write_lock(
+            &dependencies,
+            &[Some(IntegrityChecksum("deadbeef".to_string()))],
+            LockWriteMode::Append,
+        )
+        .unwrap();
         let contents = read_file_to_string(lock_file);
 
         assert_eq!(
@@ -289,18 +312,21 @@ name = "@openzeppelin-contracts"
 version = "2.3.0"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip"
 checksum = "a2d469062adeb62f7a4aada78237acae4ad3c168ba65c3ac9c76e290332c11ec"
+integrity = "deadbeef"
 
 [[dependencies]]
 name = "@openzeppelin-contracts-2"
 version = "2.6.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.6.0.zip"
 checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+integrity = "deadbeef"
 
 [[dependencies]]
 name = "@prb-test"
 version = "0.6.5"
 source = "registry+https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@prb-test~0.6.5.zip"
 checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+integrity = "deadbeef"
 "#
         );
 
@@ -318,7 +344,8 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             checksum: Some("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string())
         });
         let dependencies = vec![dependency.clone()];
-        write_lock(&dependencies, LockWriteMode::Append).unwrap();
+        write_lock(&dependencies, &[Some(IntegrityChecksum::default())], LockWriteMode::Append)
+            .unwrap();
 
         match remove_lock(&dependency) {
             Ok(_) => {}
@@ -346,7 +373,15 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
             checksum: Some("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string())
         });
         let dependencies = vec![dependency.clone(), dependency2.clone()];
-        write_lock(&dependencies, LockWriteMode::Append).unwrap();
+        write_lock(
+            &dependencies,
+            &[
+                Some(IntegrityChecksum("deadbeef".to_string())),
+                Some(IntegrityChecksum("deadbeef".to_string())),
+            ],
+            LockWriteMode::Append,
+        )
+        .unwrap();
 
         match remove_lock(&dependency) {
             Ok(_) => {}
@@ -363,6 +398,7 @@ name = "@openzeppelin-contracts2"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
 checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+integrity = "deadbeef"
 "#
         );
     }
@@ -379,7 +415,12 @@ checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
         });
 
         let dependencies = vec![dependency.clone()];
-        write_lock(&dependencies, LockWriteMode::Append).unwrap();
+        write_lock(
+            &dependencies,
+            &[Some(IntegrityChecksum("deadbeef".to_string()))],
+            LockWriteMode::Append,
+        )
+        .unwrap();
 
         match remove_lock(&Dependency::Http(HttpDependency {
             name: "non-existent".to_string(),
@@ -401,6 +442,7 @@ name = "@openzeppelin-contracts"
 version = "2.5.0"
 source = "https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.5.0.zip"
 checksum = "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016"
+integrity = "deadbeef"
 "#
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -160,19 +160,16 @@ pub fn sanitize_dependency_name(dependency_name: &str) -> String {
     sanitize_filename::sanitize_with_options(dependency_name, options)
 }
 
-#[cfg(not(test))]
 pub fn zipfile_hash(dependency: &HttpDependency) -> Result<IntegrityChecksum, DownloadError> {
+    if cfg!(test) {
+        return Ok("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".into());
+    }
     use crate::DEPENDENCY_DIR;
 
     let file_name =
         sanitize_dependency_name(&format!("{}-{}.zip", dependency.name, dependency.version));
     let path = DEPENDENCY_DIR.join(&file_name);
     hash_file(&path).map_err(|e| DownloadError::IOError { path, source: e })
-}
-
-#[cfg(test)]
-pub fn zipfile_hash(_dependency: &HttpDependency) -> Result<IntegrityChecksum, DownloadError> {
-    Ok("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".into())
 }
 
 /// Hash the contents of a Reader with SHA256

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
+use sha2::{Digest, Sha256};
 use simple_home_dir::home_dir;
 use std::{
     env,
@@ -159,4 +160,13 @@ pub fn sha256_digest(dependency: &HttpDependency) -> String {
 #[cfg(test)]
 pub fn sha256_digest(_dependency: &HttpDependency) -> String {
     "5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".to_string()
+}
+
+pub fn hash_content<R: Read>(content: &mut R) -> [u8; 32] {
+    let mut hasher = <Sha256 as Digest>::new();
+    let mut buf = [0; 1024];
+    while let Ok(size) = content.read(&mut buf) {
+        hasher.update(&buf[0..size]);
+    }
+    hasher.finalize().into()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -161,9 +161,6 @@ pub fn sanitize_dependency_name(dependency_name: &str) -> String {
 }
 
 pub fn zipfile_hash(dependency: &HttpDependency) -> Result<IntegrityChecksum, DownloadError> {
-    if cfg!(test) {
-        return Ok("5019418b1e9128185398870f77a42e51d624c44315bb1572e7545be51d707016".into());
-    }
     use crate::DEPENDENCY_DIR;
 
     let file_name =

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -258,7 +258,7 @@ pub fn hash_file(path: impl AsRef<Path>) -> Result<IntegrityChecksum, std::io::E
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     let bytes = hash_content(&mut reader);
-    Ok(const_hex::encode(&bytes).into())
+    Ok(const_hex::encode(bytes).into())
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -297,6 +297,15 @@ mod tests {
     }
 
     #[test]
+    fn test_hash_content_content_sensitive() {
+        let mut content = "foobar".as_bytes();
+        let hash = hash_content(&mut content);
+        let mut content2 = "baz".as_bytes();
+        let hash2 = hash_content(&mut content2);
+        assert_ne!(hash, hash2);
+    }
+
+    #[test]
     fn test_hash_file() {
         let file = create_random_file("test", "txt");
         let hash = hash_file(&file).unwrap();
@@ -310,6 +319,26 @@ mod tests {
         let hash = hash_folder(&folder, None).unwrap();
         fs::remove_dir_all(&folder).unwrap();
         assert_eq!(hash, "b0bbe5dbf490a7120cce269564ed7a1f1f016ff50ccbb38eb288849f0ce7ab49".into());
+    }
+
+    #[test]
+    fn test_hash_folder_path_sensitive() {
+        let folder1 = create_test_folder("test", "test_hash_folder_path_sensitive");
+        let folder2 = create_test_folder("test", "test_hash_folder_path_sensitive2");
+        let hash1 = hash_folder(&folder1, None).unwrap();
+        let hash2 = hash_folder(&folder2, None).unwrap();
+        fs::remove_dir_all(&folder1).unwrap();
+        fs::remove_dir_all(&folder2).unwrap();
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_hash_folder_ignore_path() {
+        let folder = create_test_folder("test", "test_hash_folder_ignore_path");
+        let hash1 = hash_folder(&folder, None).unwrap();
+        let hash2 = hash_folder(&folder, Some(folder.join("a.txt"))).unwrap();
+        fs::remove_dir_all(&folder).unwrap();
+        assert_ne!(hash1, hash2);
     }
 
     fn create_random_file(target_dir: impl AsRef<Path>, extension: &str) -> PathBuf {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -202,7 +202,7 @@ pub fn hash_folder(
     // a list of hashes, one for each DirEntry
     let hashes = Arc::new(Mutex::new(Vec::with_capacity(100)));
     // we use a parallel walker to speed things up
-    let walker = WalkBuilder::new(folder_path).build_parallel();
+    let walker = WalkBuilder::new(folder_path).hidden(false).build_parallel();
     walker.run(|| {
         let ignore_path = ignore_path.clone();
         let seen_ignore_path = Arc::clone(&seen_ignore_path);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -177,7 +177,7 @@ pub fn sha256_digest(_dependency: &HttpDependency) -> String {
 /// Hash the contents of a Reader with SHA256
 pub fn hash_content<R: Read>(content: &mut R) -> [u8; 32] {
     let mut hasher = <Sha256 as Digest>::new();
-    let mut buf = [0; 8192];
+    let mut buf = [0; 1024];
     while let Ok(size) = content.read(&mut buf) {
         if size == 0 {
             break;

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -114,6 +114,7 @@ fn filter_files_to_copy(root_directory_path: impl AsRef<Path>) -> Vec<PathBuf> {
     let files_to_copy = Arc::new(Mutex::new(Vec::with_capacity(100)));
     let walker = WalkBuilder::new(root_directory_path)
         .add_custom_ignore_filename(".soldeerignore")
+        .hidden(false)
         .build_parallel();
     walker.run(|| {
         let files_to_copy = Arc::clone(&files_to_copy);

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -133,7 +133,7 @@ fn filter_files_to_copy(root_directory_path: impl AsRef<Path>) -> Vec<PathBuf> {
         })
     });
 
-    Arc::try_unwrap(files_to_copy)
+    Arc::into_inner(files_to_copy)
         .expect("Arc should have no other strong references")
         .into_inner()
         .expect("mutex should not be poisoned")

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -2,8 +2,9 @@ use crate::{
     auth::get_token,
     errors::{AuthError, PublishError},
     remote::get_project_id,
-    utils::{get_base_url, get_current_working_dir, read_file, read_file_to_string},
+    utils::{get_base_url, read_file},
 };
+use ignore::{WalkBuilder, WalkState};
 use regex::Regex;
 use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE},
@@ -14,10 +15,9 @@ use std::{
     fs::{remove_file, File},
     io::{self, Read, Write},
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
-use walkdir::WalkDir;
 use yansi::Paint as _;
-use yash_fnmatch::{without_escape, Pattern};
 use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
 pub type Result<T> = std::result::Result<T, PublishError>;
@@ -110,69 +110,32 @@ fn zip_file(
     Ok(zip_file_path)
 }
 
-fn filter_files_to_copy(root_directory_path: &Path) -> Vec<PathBuf> {
-    let ignore_files: Vec<String> = read_ignore_file();
-
-    let root_directory: &str = &(root_directory_path.to_str().unwrap().to_owned() + "/");
-    let mut files_to_copy: Vec<PathBuf> = Vec::new();
-    for entry in WalkDir::new(root_directory).into_iter().filter_map(|e| e.ok()) {
-        let is_dir = entry.path().is_dir();
-        let file_path: String = entry.path().to_str().unwrap().to_string();
-        if file_path.is_empty() || is_dir {
-            continue;
-        }
-        let mut found: bool = false;
-        for ignore_file in ignore_files.iter() {
-            let p = Pattern::parse(without_escape(ignore_file)).unwrap();
-            let exists = p.find(&file_path);
-            if exists.is_some() {
-                found = true;
-                break;
+fn filter_files_to_copy(root_directory_path: impl AsRef<Path>) -> Vec<PathBuf> {
+    let files_to_copy = Arc::new(Mutex::new(Vec::with_capacity(100)));
+    let walker = WalkBuilder::new(root_directory_path)
+        .add_custom_ignore_filename(".soldeerignore")
+        .build_parallel();
+    walker.run(|| {
+        let files_to_copy = Arc::clone(&files_to_copy);
+        // function executed for each DirEntry
+        Box::new(move |result| {
+            let Ok(entry) = result else {
+                return WalkState::Continue;
+            };
+            let path = entry.path();
+            if path.is_dir() {
+                return WalkState::Continue;
             }
-        }
+            let mut files_to_copy = files_to_copy.lock().expect("mutex should not be poisoned");
+            files_to_copy.push(path.to_path_buf());
+            WalkState::Continue
+        })
+    });
 
-        if found {
-            continue;
-        }
-
-        files_to_copy.push(entry.path().to_path_buf());
-    }
-    files_to_copy
-}
-
-fn read_ignore_file() -> Vec<String> {
-    let mut current_dir = get_current_working_dir();
-    if cfg!(test) {
-        current_dir = get_current_working_dir().join("test");
-    }
-    let gitignore = current_dir.join(".gitignore");
-    let soldeerignore = current_dir.join(".soldeerignore");
-
-    let mut files: Vec<String> = Vec::new();
-
-    if soldeerignore.exists() {
-        let contents = read_file_to_string(&soldeerignore);
-        let current_read_file = contents.lines();
-        files.append(&mut escape_lines(current_read_file.collect()));
-    }
-
-    if gitignore.exists() {
-        let contents = read_file_to_string(&gitignore);
-        let current_read_file = contents.lines();
-        files.append(&mut escape_lines(current_read_file.collect()));
-    }
-
-    files
-}
-
-fn escape_lines(lines: Vec<&str>) -> Vec<String> {
-    let mut escaped_liens: Vec<String> = vec![];
-    for line in lines {
-        if !line.trim().is_empty() {
-            escaped_liens.push(line.trim().to_string());
-        }
-    }
-    escaped_liens
+    Arc::try_unwrap(files_to_copy)
+        .expect("Arc should have no other strong references")
+        .into_inner()
+        .expect("mutex should not be poisoned")
 }
 
 async fn push_to_repo(
@@ -238,77 +201,11 @@ async fn push_to_repo(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::get_current_working_dir;
     use io::Cursor;
     use rand::{distributions::Alphanumeric, Rng};
     use serial_test::serial;
     use std::fs::{self, create_dir_all, remove_dir_all, remove_file};
-
-    #[test]
-    #[serial]
-    fn read_ignore_files_only_soldeerignore() {
-        let soldeerignore = define_ignore_file(false);
-        let gitignore = define_ignore_file(true);
-        let _ = remove_file(gitignore);
-        let ignore_contents = r#"
-*.toml
-*.zip
-        "#;
-        write_to_ignore(&soldeerignore, ignore_contents);
-        let expected_results: Vec<String> = vec!["*.toml".to_string(), "*.zip".to_string()];
-
-        assert_eq!(read_ignore_file(), expected_results);
-        let _ = remove_file(soldeerignore);
-    }
-
-    #[test]
-    #[serial]
-    fn read_ignore_files_only_gitignore() {
-        let soldeerignore = define_ignore_file(false);
-        let gitignore = define_ignore_file(true);
-        let _ = remove_file(soldeerignore);
-
-        let ignore_contents = r#"
-*.toml
-*.zip
-        "#;
-        write_to_ignore(&gitignore, ignore_contents);
-        let expected_results: Vec<String> = vec!["*.toml".to_string(), "*.zip".to_string()];
-
-        assert_eq!(read_ignore_file(), expected_results);
-        let _ = remove_file(gitignore);
-    }
-
-    #[test]
-    #[serial]
-    fn read_ignore_files_both_gitignore_soldeerignore() {
-        let soldeerignore = define_ignore_file(false);
-        let gitignore = define_ignore_file(true);
-        let _ = remove_file(&soldeerignore);
-        let _ = remove_file(&gitignore);
-
-        let ignore_contents_git = r#"
-*.toml
-*.zip
-        "#;
-        write_to_ignore(&gitignore, ignore_contents_git);
-
-        let ignore_contents_soldeer = r#"
-        *.sol
-        *.txt
-                "#;
-        write_to_ignore(&soldeerignore, ignore_contents_soldeer);
-
-        let expected_results: Vec<String> = vec![
-            "*.sol".to_string(),
-            "*.txt".to_string(),
-            "*.toml".to_string(),
-            "*.zip".to_string(),
-        ];
-
-        assert_eq!(read_ignore_file(), expected_results);
-        let _ = remove_file(gitignore);
-        let _ = remove_file(soldeerignore);
-    }
 
     #[test]
     #[serial]
@@ -317,16 +214,16 @@ mod tests {
         let _ = remove_dir_all(&target_dir);
         let _ = create_dir_all(&target_dir);
 
-        let soldeerignore = define_ignore_file(false);
-        let gitignore = define_ignore_file(true);
+        let soldeerignore = define_ignore_file(&target_dir, false);
+        let gitignore = define_ignore_file(&target_dir, true);
         let _ = remove_file(soldeerignore);
 
         let mut ignored_files = vec![];
         let mut filtered_files = vec![];
-        ignored_files.push(create_random_file(&target_dir, "toml".to_string()));
-        ignored_files.push(create_random_file(&target_dir, "zip".to_string()));
-        ignored_files.push(create_random_file(&target_dir, "toml".to_string()));
-        filtered_files.push(create_random_file(&target_dir, "txt".to_string()));
+        ignored_files.push(create_random_file(&target_dir, "toml"));
+        ignored_files.push(create_random_file(&target_dir, "zip"));
+        ignored_files.push(create_random_file(&target_dir, "toml"));
+        filtered_files.push(create_random_file(&target_dir, "txt"));
 
         let ignore_contents_git = r#"
 *.toml
@@ -350,8 +247,8 @@ mod tests {
         let _ = remove_dir_all(&target_dir);
         let _ = create_dir_all(&target_dir);
 
-        let soldeerignore = define_ignore_file(false);
-        let gitignore = define_ignore_file(true);
+        let soldeerignore = define_ignore_file(&target_dir, false);
+        let gitignore = define_ignore_file(&target_dir, true);
         let _ = remove_file(soldeerignore);
 
         // divide ignored vs filtered files to check them later
@@ -379,27 +276,27 @@ mod tests {
         // --- --- --- --- zip <= ignored
         // --- --- --- --- toml <= ignored
 
-        let random_dir = create_random_directory(&target_dir, "".to_string());
-        let broadcast_dir = create_random_directory(&target_dir, "broadcast".to_string());
+        let random_dir = create_random_directory(&target_dir, None);
+        let broadcast_dir = create_random_directory(&target_dir, Some("broadcast"));
 
-        let the_31337_dir = create_random_directory(&broadcast_dir, "31337".to_string());
-        let random_dir_in_broadcast = create_random_directory(&broadcast_dir, "".to_string());
-        let dry_run_dir = create_random_directory(&random_dir_in_broadcast, "dry_run".to_string());
+        let the_31337_dir = create_random_directory(&broadcast_dir, Some("31337"));
+        let random_dir_in_broadcast = create_random_directory(&broadcast_dir, None);
+        let dry_run_dir = create_random_directory(&random_dir_in_broadcast, Some("dry_run"));
 
-        ignored_files.push(create_random_file(&random_dir, "toml".to_string()));
-        filtered_files.push(create_random_file(&random_dir, "zip".to_string()));
+        ignored_files.push(create_random_file(&random_dir, "toml"));
+        filtered_files.push(create_random_file(&random_dir, "zip"));
 
-        ignored_files.push(create_random_file(&broadcast_dir, "toml".to_string()));
-        filtered_files.push(create_random_file(&broadcast_dir, "zip".to_string()));
+        ignored_files.push(create_random_file(&broadcast_dir, "toml"));
+        filtered_files.push(create_random_file(&broadcast_dir, "zip"));
 
-        ignored_files.push(create_random_file(&the_31337_dir, "toml".to_string()));
-        ignored_files.push(create_random_file(&the_31337_dir, "zip".to_string()));
+        ignored_files.push(create_random_file(&the_31337_dir, "toml"));
+        ignored_files.push(create_random_file(&the_31337_dir, "zip"));
 
-        filtered_files.push(create_random_file(&random_dir_in_broadcast, "zip".to_string()));
-        filtered_files.push(create_random_file(&random_dir_in_broadcast, "toml".to_string()));
+        filtered_files.push(create_random_file(&random_dir_in_broadcast, "zip"));
+        filtered_files.push(create_random_file(&random_dir_in_broadcast, "toml"));
 
-        ignored_files.push(create_random_file(&dry_run_dir, "zip".to_string()));
-        ignored_files.push(create_random_file(&dry_run_dir, "toml".to_string()));
+        ignored_files.push(create_random_file(&dry_run_dir, "zip"));
+        ignored_files.push(create_random_file(&dry_run_dir, "toml"));
 
         let ignore_contents_git = r#"
 *.toml
@@ -417,7 +314,7 @@ mod tests {
                 continue;
             }
 
-            assert!(filtered_files.contains(&res));
+            assert!(filtered_files.contains(&res), "File {:?} not found in filtered files", res);
         }
 
         let _ = remove_file(gitignore);
@@ -441,11 +338,11 @@ mod tests {
         // --- --- --- random_file_3.txt
         // --- --- random_file_2.txt
         // --- random_file_1.txt
-        let random_dir_1 = create_random_directory(&target_dir, "".to_string());
-        let random_dir_2 = create_random_directory(Path::new(&random_dir_1), "".to_string());
-        let random_file_1 = create_random_file(&target_dir, "txt".to_string());
-        let random_file_2 = create_random_file(Path::new(&random_dir_1), "txt".to_string());
-        let random_file_3 = create_random_file(Path::new(&random_dir_2), "txt".to_string());
+        let random_dir_1 = create_random_directory(&target_dir, None);
+        let random_dir_2 = create_random_directory(Path::new(&random_dir_1), None);
+        let random_file_1 = create_random_file(&target_dir, "txt");
+        let random_file_2 = create_random_file(Path::new(&random_dir_1), "txt");
+        let random_file_3 = create_random_file(Path::new(&random_dir_2), "txt");
 
         let files_to_copy: Vec<PathBuf> =
             vec![random_file_1.clone(), random_file_3.clone(), random_file_2.clone()];
@@ -483,48 +380,39 @@ mod tests {
         let _ = remove_dir_all(&target_dir_unzip);
     }
 
-    fn define_ignore_file(git: bool) -> PathBuf {
+    fn define_ignore_file(target_dir: impl AsRef<Path>, git: bool) -> PathBuf {
         let mut target = ".soldeerignore";
         if git {
             target = ".gitignore";
         }
-        get_current_working_dir().join("test").join(target)
+        target_dir.as_ref().to_path_buf().join(target)
     }
 
-    fn write_to_ignore(target_file: &PathBuf, content: &str) {
-        if target_file.exists() {
-            let _ = remove_file(target_file);
+    fn write_to_ignore(target_file: impl AsRef<Path>, contents: &str) {
+        if target_file.as_ref().exists() {
+            let _ = remove_file(&target_file);
         }
-        let mut file: std::fs::File =
-            fs::OpenOptions::new().create_new(true).write(true).open(target_file).unwrap();
-        if let Err(e) = write!(file, "{}", content) {
-            eprintln!("Couldn't write to the config file: {}", e);
-        }
+        fs::write(&target_file, contents).expect("Could not write to ignore file");
     }
 
-    fn create_random_file(target_dir: &Path, extension: String) -> PathBuf {
+    fn create_random_file(target_dir: impl AsRef<Path>, extension: &str) -> PathBuf {
         let s: String =
             rand::thread_rng().sample_iter(&Alphanumeric).take(7).map(char::from).collect();
-        let target = target_dir.join(format!("random{}.{}", s, extension));
-        let mut file: std::fs::File =
-            fs::OpenOptions::new().create_new(true).write(true).open(&target).unwrap();
-        if let Err(e) = write!(file, "this is a test file") {
-            eprintln!("Couldn't write to the config file: {}", e);
-        }
+        let target = target_dir.as_ref().join(format!("random{}.{}", s, extension));
+        fs::write(&target, "this is a test file").expect("Could not write to test file");
         target
     }
-    fn create_random_directory(target_dir: &Path, name: String) -> PathBuf {
-        let s: String =
-            rand::thread_rng().sample_iter(&Alphanumeric).take(7).map(char::from).collect();
 
-        if name.is_empty() {
-            let target = target_dir.join(format!("random{}", s));
-            let _ = create_dir_all(&target);
-            target
-        } else {
-            let target = target_dir.join(name);
-            let _ = create_dir_all(&target);
-            target
-        }
+    fn create_random_directory(target_dir: impl AsRef<Path>, name: Option<&str>) -> PathBuf {
+        let target = match name {
+            Some(name) => target_dir.as_ref().join(name),
+            None => {
+                let s: String =
+                    rand::thread_rng().sample_iter(&Alphanumeric).take(7).map(char::from).collect();
+                target_dir.as_ref().join(format!("random{}", s))
+            }
+        };
+        let _ = create_dir_all(&target);
+        target
     }
 }

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -220,7 +220,7 @@ mod tests {
         let _ = remove_file(soldeerignore);
 
         let mut ignored_files = vec![];
-        let mut filtered_files = vec![];
+        let mut filtered_files = vec![gitignore.clone()];
         ignored_files.push(create_random_file(&target_dir, "toml"));
         ignored_files.push(create_random_file(&target_dir, "zip"));
         ignored_files.push(create_random_file(&target_dir, "toml"));
@@ -234,8 +234,8 @@ mod tests {
 
         let result = filter_files_to_copy(&target_dir);
         assert_eq!(filtered_files.len(), result.len());
-        let file = Path::new(&filtered_files[0]);
-        assert_eq!(file, result[0]);
+        let file = Path::new(&filtered_files[1]);
+        assert_eq!(file, result[1]);
 
         let _ = remove_file(gitignore);
         let _ = remove_dir_all(target_dir);

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -254,7 +254,7 @@ mod tests {
 
         // divide ignored vs filtered files to check them later
         let mut ignored_files = vec![];
-        let mut filtered_files = vec![];
+        let mut filtered_files = vec![gitignore.clone()];
 
         // initial dir to test the ignore
         let target_dir = get_current_working_dir().join("test").join("test_push");

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -234,8 +234,9 @@ mod tests {
 
         let result = filter_files_to_copy(&target_dir);
         assert_eq!(filtered_files.len(), result.len());
-        let file = Path::new(&filtered_files[1]);
-        assert_eq!(file, result[1]);
+        for res in result {
+            assert!(filtered_files.contains(&res), "File {:?} not found in filtered files", res);
+        }
 
         let _ = remove_file(gitignore);
         let _ = remove_dir_all(target_dir);


### PR DESCRIPTION
This is the first step towards having a way to skip install of already installed dependencies. The next step will involve a refactor for the download/extract pipeline and is out of the scope of this PR.

This checksum would only be used for zip dependencies. Deps cloned with git could be checked for integrity with `git diff` for example, and a full re-download/clone is probably not necessary in case of failed integrity check. A simple forced checkout should suffice.

Took the chance to refactor the dir-walking for the `push` command.

### Breaking changes

- `unzip_dependencies` returns a `Result<Vec<Option<IntegrityChecksum>>>`
- `unzip_dependency` returns a `Result<IntegrityChecksum>`
- `write_lock` takes in an additional parameter `integrity_checksums: &[Option<IntegrityChecksum>]`
- `sha256_digest` was renamed to `zipfile_hash` and returns a `Result<IntegrityChecksum>`

Closes #128 