### PR TITLE
Recursive Dependencies

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -71,8 +71,13 @@ pub struct Install {
     pub rev: Option<String>,
 
     /// If set, this command will delete the existing remappings and re-create them
-    #[arg(long, default_value_t = false)]
+    #[arg(short = 'g', long, default_value_t = false)]
     pub regenerate_remappings: bool,
+
+    /// If set, this command will install the recursive dependencies (via submodules or via
+    /// soldeer)
+    #[arg(short = 'd', long, default_value_t = false)]
+    pub recursive_deps: bool,
 }
 
 /// Update dependencies by reading the config file
@@ -80,8 +85,13 @@ pub struct Install {
 #[clap(after_help = "For more information, read the README.md")]
 pub struct Update {
     /// If set, this command will delete the existing remappings and re-create them
-    #[arg(long, default_value_t = false)]
+    #[arg(short = 'g', long, default_value_t = false)]
     pub regenerate_remappings: bool,
+
+    /// If set, this command will install the recursive dependencies (via submodules or via
+    /// soldeer)
+    #[arg(short = 'd', long, default_value_t = false)]
+    pub recursive_deps: bool,
 }
 
 /// Display the version of Soldeer

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,9 @@ pub struct SoldeerConfig {
 
     #[serde(default)]
     pub remappings_location: RemappingsLocation,
+
+    #[serde(default)]
+    pub recursive_deps: bool,
 }
 
 impl Default for SoldeerConfig {
@@ -56,6 +59,7 @@ impl Default for SoldeerConfig {
             remappings_version: true,
             remappings_prefix: String::new(),
             remappings_location: Default::default(),
+            recursive_deps: false,
         }
     }
 }

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -121,7 +121,7 @@ pub async fn download_dependency(
     };
 
     if recursive_deps {
-        check_recursiveness(dependency).unwrap();
+        install_subdependencies(dependency)?;
     }
     println!("{}", format!("Dependency {dependency} downloaded!").green());
 
@@ -285,7 +285,7 @@ fn transform_git_to_http(url: &str) -> String {
     }
 }
 
-fn check_recursiveness(dependency: &Dependency) -> Result<()> {
+fn install_subdependencies(dependency: &Dependency) -> Result<()> {
     let dep_name =
         sanitize_dependency_name(&format!("{}-{}", dependency.name(), dependency.version()));
 
@@ -305,7 +305,7 @@ fn check_recursiveness(dependency: &Dependency) -> Result<()> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let status = result.status().unwrap();
+    let status = result.status().expect("subdependency via GIT failed");
 
     if !status.success() {
         println!("{}", "Dependency has no submodule dependency.".yellow());
@@ -319,7 +319,7 @@ fn check_recursiveness(dependency: &Dependency) -> Result<()> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let status = result.status().unwrap();
+    let status = result.status().expect("subdependency via Soldeer failed");
 
     if !status.success() {
         println!("{}", "Dependency has no Soldeer dependency.".yellow());
@@ -828,7 +828,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn download_dependency_with_recursiveness_on_soldeer_success() {
+    async fn download_dependency_with_subdependencies_on_soldeer_success() {
         clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
         let dependency = Dependency::Git(GitDependency {
@@ -854,7 +854,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn download_dependency_with_recursiveness_on_git_success() {
+    async fn download_dependency_with_subdependencies_on_git_success() {
         clean_dependency_directory();
         let mut dependencies: Vec<Dependency> = Vec::new();
         let dependency = Dependency::Git(GitDependency {

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -24,6 +24,7 @@ pub type Result<T> = std::result::Result<T, DownloadError>;
 pub async fn download_dependencies(
     dependencies: &[Dependency],
     clean: bool,
+    recursive_deps: bool,
 ) -> Result<Vec<DownloadResult>> {
     // clean dependencies folder if flag is true
     if clean {
@@ -43,7 +44,7 @@ pub async fn download_dependencies(
     for dep in dependencies {
         set.spawn({
             let d = dep.clone();
-            async move { download_dependency(&d, true).await }
+            async move { download_dependency(&d, true, recursive_deps).await }
         });
     }
 
@@ -80,6 +81,7 @@ pub struct DownloadResult {
 pub async fn download_dependency(
     dependency: &Dependency,
     skip_folder_check: bool,
+    recursive_deps: bool,
 ) -> Result<DownloadResult> {
     let dependency_directory: PathBuf = DEPENDENCY_DIR.clone();
     // if we called this method from `download_dependencies` we don't need to check if the folder
@@ -117,6 +119,10 @@ pub async fn download_dependency(
             }
         }
     };
+
+    if recursive_deps {
+        check_recursiveness(dependency).unwrap();
+    }
     println!("{}", format!("Dependency {dependency} downloaded!").green());
 
     Ok(res)
@@ -146,7 +152,7 @@ async fn download_via_git(
     dependency: &GitDependency,
     dependency_directory: &Path,
 ) -> Result<String> {
-    println!("{}", format!("Started git download of {dependency}").green());
+    println!("{}", format!("Started GIT download of {dependency}").green());
     let target_dir =
         sanitize_dependency_name(&format!("{}-{}", dependency.name, dependency.version));
     let path = dependency_directory.join(target_dir);
@@ -157,8 +163,6 @@ async fn download_via_git(
 
     let http_url = transform_git_to_http(&dependency.git);
     let mut git_clone = Command::new("git");
-    let mut git_checkout = Command::new("git");
-    let mut git_get_commit = Command::new("git");
 
     let result = git_clone
         .args(["clone", &http_url, &path_str])
@@ -178,14 +182,11 @@ async fn download_via_git(
 
     let rev = match dependency.rev.clone() {
         Some(rev) => {
+            let mut git_get_commit = Command::new("git");
             let result = git_get_commit
-                .args([
-                    format!("--work-tree={}", path_str),
-                    format!("--git-dir={}", path.join(".git").to_string_lossy()),
-                    "checkout".to_string(),
-                    rev.to_string(),
-                ])
+                .args(["checkout".to_string(), rev.to_string()])
                 .env("GIT_TERMINAL_PROMPT", "0")
+                .current_dir(&path)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
@@ -201,15 +202,12 @@ async fn download_via_git(
             rev
         }
         None => {
+            let mut git_checkout = Command::new("git");
+
             let result = git_checkout
-                .args([
-                    format!("--work-tree={}", path_str),
-                    format!("--git-dir={}", path.join(".git").to_string_lossy()),
-                    "rev-parse".to_string(),
-                    "--verify".to_string(),
-                    "HEAD".to_string(),
-                ])
+                .args(["rev-parse".to_string(), "--verify".to_string(), "HEAD".to_string()])
                 .env("GIT_TERMINAL_PROMPT", "0")
+                .current_dir(&path)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
@@ -287,6 +285,49 @@ fn transform_git_to_http(url: &str) -> String {
     }
 }
 
+fn check_recursiveness(dependency: &Dependency) -> Result<()> {
+    let dep_name =
+        sanitize_dependency_name(&format!("{}-{}", dependency.name(), dependency.version()));
+
+    let dep_dir = DEPENDENCY_DIR.join(dep_name);
+    if !dep_dir.exists() {
+        return Err(DownloadError::RecursivenessError(
+            "Dependency directory does not exists".to_string(),
+        ));
+    }
+
+    let mut git = Command::new("git");
+
+    let result = git
+        .args(["submodule", "update", "--init", "--recursive"])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .current_dir(&dep_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let status = result.status().unwrap();
+
+    if !status.success() {
+        println!("{}", "Dependency has no submodule dependency.".yellow());
+    }
+
+    let mut soldeer = Command::new("forge");
+
+    let result = soldeer
+        .args(["soldeer", "install"])
+        .current_dir(&dep_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let status = result.status().unwrap();
+
+    if !status.success() {
+        println!("{}", "Dependency has no Soldeer dependency.".yellow());
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::vec_init_then_push)]
 mod tests {
@@ -309,7 +350,7 @@ mod tests {
             checksum: None
         });
         dependencies.push(dependency.clone());
-        let results = download_dependencies(&dependencies, false).await.unwrap();
+        let results = download_dependencies(&dependencies, false, false).await.unwrap();
         let path_zip =
             DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name(), &dependency.version()));
         assert!(path_zip.exists());
@@ -330,7 +371,7 @@ mod tests {
             rev: None,
         });
         dependencies.push(dependency.clone());
-        let results = download_dependencies(&dependencies, false).await.unwrap();
+        let results = download_dependencies(&dependencies, false, false).await.unwrap();
         let path_dir =
             DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         assert!(path_dir.exists());
@@ -352,7 +393,7 @@ mod tests {
             rev: None,
         });
         dependencies.push(dependency.clone());
-        let results = download_dependencies(&dependencies, false).await.unwrap();
+        let results = download_dependencies(&dependencies, false, false).await.unwrap();
         let path_dir =
             DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         assert!(path_dir.exists());
@@ -374,7 +415,7 @@ mod tests {
             rev: Some("7a0663eaf7488732f39550be655bad6694974cb3".to_string()),
         });
         dependencies.push(dependency.clone());
-        let results = download_dependencies(&dependencies, false).await.unwrap();
+        let results = download_dependencies(&dependencies, false, false).await.unwrap();
         let path_dir =
             DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         assert!(path_dir.exists());
@@ -403,7 +444,7 @@ mod tests {
             rev: None,
         });
         dependencies.push(dependency.clone());
-        let results = download_dependencies(&dependencies, false).await.unwrap();
+        let results = download_dependencies(&dependencies, false, false).await.unwrap();
         let path_dir =
             DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         assert!(path_dir.exists());
@@ -433,7 +474,7 @@ mod tests {
         });
 
         dependencies.push(dependency_two.clone());
-        let results = download_dependencies(&dependencies, false).await.unwrap();
+        let results = download_dependencies(&dependencies, false, false).await.unwrap();
         let mut path_zip = DEPENDENCY_DIR.join(format!(
             "{}-{}.zip",
             &dependency_one.name(),
@@ -473,7 +514,7 @@ mod tests {
         });
 
         dependencies.push(dependency_two.clone());
-        let results = download_dependencies(&dependencies, false).await.unwrap();
+        let results = download_dependencies(&dependencies, false, false).await.unwrap();
         let mut path_dir = DEPENDENCY_DIR.join(format!(
             "{}-{}",
             &dependency_one.name(),
@@ -517,7 +558,7 @@ mod tests {
         });
         dependencies.push(dependency_one.clone());
 
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
         let path_zip = DEPENDENCY_DIR.join(format!(
             "{}-{}.zip",
             &dependency_one.name(),
@@ -535,7 +576,7 @@ mod tests {
         dependencies = Vec::new();
         dependencies.push(dependency_two.clone());
 
-        let results = download_dependencies(&dependencies, false).await.unwrap();
+        let results = download_dependencies(&dependencies, false, false).await.unwrap();
         let size_of_two = fs::metadata(Path::new(&path_zip)).unwrap().len();
 
         assert!(size_of_two > size_of_one);
@@ -556,7 +597,7 @@ mod tests {
         });
 
         dependencies.push(dependency_old.clone());
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
 
         // making sure the dependency exists so we can check the deletion
         let path_zip_old = DEPENDENCY_DIR.join(format!(
@@ -575,7 +616,7 @@ mod tests {
         dependencies = Vec::new();
         dependencies.push(dependency.clone());
 
-        let results = download_dependencies(&dependencies, true).await.unwrap();
+        let results = download_dependencies(&dependencies, true, false).await.unwrap();
         let path_zip =
             DEPENDENCY_DIR.join(format!("{}-{}.zip", &dependency.name(), &dependency.version()));
         assert!(!path_zip_old.exists());
@@ -598,7 +639,7 @@ mod tests {
         });
         dependencies.push(dependency.clone());
 
-        match download_dependencies(&dependencies, false).await {
+        match download_dependencies(&dependencies, false, false).await {
             Ok(_) => {
                 assert_eq!("Invalid state", "");
             }
@@ -622,7 +663,7 @@ mod tests {
         });
         dependencies.push(dependency.clone());
 
-        match download_dependencies(&dependencies, false).await {
+        match download_dependencies(&dependencies, false, false).await {
             Ok(_) => {
                 assert_eq!("Invalid state", "");
             }
@@ -646,7 +687,7 @@ mod tests {
             checksum: None
         });
         dependencies.push(dependency.clone());
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
         let path = DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
         match unzip_dependencies(&dependencies) {
             Ok(_) => {
@@ -675,7 +716,7 @@ mod tests {
             checksum: None,
         });
         dependencies.push(dependency.clone());
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
         match unzip_dependencies(&dependencies) {
             Ok(_) => {
                 clean_dependency_directory();
@@ -698,7 +739,7 @@ mod tests {
             url: Some("https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/3_3_0-rc_2_22-01-2024_13:12:57_contracts.zip".to_string()),
             checksum: None,
         }));
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
         unzip_dependency(dependencies[0].as_http().unwrap()).unwrap();
         healthcheck_dependency(&dependencies[0]).unwrap();
         assert!(DEPENDENCY_DIR
@@ -773,7 +814,7 @@ mod tests {
         });
         dependencies.push(dependency.clone());
 
-        match download_dependencies(&dependencies, false).await {
+        match download_dependencies(&dependencies, false, false).await {
             Ok(_) => {}
             Err(_) => {
                 assert_eq!("Invalid state", "");
@@ -783,5 +824,53 @@ mod tests {
         assert!(!DEPENDENCY_DIR
             .join(format!("{}~{}", dependency.name(), dependency.version()))
             .exists());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn download_dependency_with_recursiveness_on_soldeer_success() {
+        clean_dependency_directory();
+        let mut dependencies: Vec<Dependency> = Vec::new();
+        let dependency = Dependency::Git(GitDependency {
+            name: "dep1".to_string(),
+            version: "1.0".to_string(),
+            git: "git@gitlab.com:mario4582928/mario-soldeer-dependency.git".to_string(),
+            rev: None,
+        });
+        dependencies.push(dependency.clone());
+        let results = download_dependencies(&dependencies, false, true).await.unwrap();
+        let path_dir =
+            DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
+        assert!(path_dir.exists());
+        assert!(path_dir
+            .join("dependencies")
+            .join("@openzeppelin-contracts-5.0.2")
+            .join("README.md")
+            .exists());
+        assert!(results.len() == 1);
+        assert!(!results[0].hash.is_empty());
+        clean_dependency_directory();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn download_dependency_with_recursiveness_on_git_success() {
+        clean_dependency_directory();
+        let mut dependencies: Vec<Dependency> = Vec::new();
+        let dependency = Dependency::Git(GitDependency {
+            name: "dep1".to_string(),
+            version: "1.0".to_string(),
+            git: "git@gitlab.com:mario4582928/mario-git-submodule.git".to_string(),
+            rev: None,
+        });
+        dependencies.push(dependency.clone());
+        let results = download_dependencies(&dependencies, false, true).await.unwrap();
+        let path_dir =
+            DEPENDENCY_DIR.join(format!("{}-{}", &dependency.name(), &dependency.version()));
+        assert!(path_dir.exists());
+        assert!(path_dir.join("lib").join("mario").join("README.md").exists());
+        assert!(results.len() == 1);
+        assert!(!results[0].hash.is_empty());
+        clean_dependency_directory();
     }
 }

--- a/src/dependency_downloader.rs
+++ b/src/dependency_downloader.rs
@@ -170,8 +170,8 @@ async fn download_via_git(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let status = result.status().unwrap();
-    let out = result.output().unwrap();
+    let status = result.status().expect("Getting clone status failed");
+    let out = result.output().expect("Getting clone output failed");
 
     if !status.success() {
         let _ = fs::remove_dir_all(&path);
@@ -190,8 +190,8 @@ async fn download_via_git(
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
-            let out = result.output().unwrap();
-            let status = result.status().unwrap();
+            let out = result.output().expect("Checkout to revision status failed");
+            let status = result.status().expect("Checkout to revision getting output failed");
 
             if !status.success() {
                 let _ = fs::remove_dir_all(&path);
@@ -211,8 +211,8 @@ async fn download_via_git(
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
-            let out = result.output().unwrap();
-            let status = result.status().unwrap();
+            let out = result.output().expect("Getting revision status failed");
+            let status = result.status().expect("Getting revision output failed");
             if !status.success() {
                 let _ = fs::remove_dir_all(&path);
                 return Err(DownloadError::GitError(
@@ -305,7 +305,7 @@ fn install_subdependencies(dependency: &Dependency) -> Result<()> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let status = result.status().expect("subdependency via GIT failed");
+    let status = result.status().expect("Subdependency via GIT failed");
 
     if !status.success() {
         println!("{}", "Dependency has no submodule dependency.".yellow());
@@ -319,7 +319,7 @@ fn install_subdependencies(dependency: &Dependency) -> Result<()> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let status = result.status().expect("subdependency via Soldeer failed");
+    let status = result.status().expect("Subdependency via Soldeer failed");
 
     if !status.success() {
         println!("{}", "Dependency has no Soldeer dependency.".yellow());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -107,6 +107,9 @@ pub enum DownloadError {
 
     #[error("error during async operation: {0}")]
     AsyncError(#[from] tokio::task::JoinError),
+
+    #[error("Could download the dependencies of this dependency {0}")]
+    RecursivenessError(String),
 }
 
 #[derive(Error, Debug)]

--- a/src/janitor.rs
+++ b/src/janitor.rs
@@ -86,7 +86,7 @@ mod tests {
             version: "2.3.0".to_string(),
             url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
             checksum: None}));
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
         unzip_dependency(dependencies[0].as_http().unwrap()).unwrap();
         healthcheck_dependency(&dependencies[0]).unwrap();
     }
@@ -102,7 +102,7 @@ mod tests {
             version: "2.3.0".to_string(),
             url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
             checksum: None }));
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
         unzip_dependency(dependencies[0].as_http().unwrap()).unwrap();
         cleanup_dependency(&dependencies[0], false).unwrap();
     }
@@ -138,7 +138,7 @@ mod tests {
             url:Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.4.0.zip".to_string()),
             checksum: None }));
 
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
         let _ = unzip_dependency(dependencies[0].as_http().unwrap());
         let result: Result<()> = cleanup_after(&dependencies);
         assert!(result.is_ok());
@@ -157,7 +157,7 @@ mod tests {
             url: Some("https://github.com/mario-eth/soldeer-versions/raw/main/all_versions/@openzeppelin-contracts~2.3.0.zip".to_string()),
             checksum: None}));
 
-        download_dependencies(&dependencies, false).await.unwrap();
+        download_dependencies(&dependencies, false, false).await.unwrap();
         unzip_dependency(dependencies[0].as_http().unwrap()).unwrap();
         dependencies.push(Dependency::Http(HttpDependency {
             name: "@openzeppelin-contracts".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,15 +58,16 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             let dependency: Dependency = get_latest_forge_std_dependency().await.map_err(|e| {
                 SoldeerError::DownloadError { dep: "forge-std".to_string(), source: e }
             })?;
-            install_dependency(dependency, true).await?;
+            install_dependency(dependency, true, false).await?;
         }
         Subcommands::Install(install) => {
             let regenerate_remappings = install.regenerate_remappings;
             let Some(dependency) = install.dependency else {
-                return update(regenerate_remappings).await; // TODO: instead, check which
-                                                            // dependencies do
-                                                            // not match the
-                                                            // integrity checksum and install those
+                return update(regenerate_remappings, install.recursive_deps).await; // TODO: instead, check which
+                                                                                    // dependencies
+                                                                                    // do
+                                                                                    // not match the
+                                                                                    // integrity checksum and install those
             };
 
             println!("{}", "🦌 Running Soldeer install 🦌".green());
@@ -96,11 +97,10 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
                 }),
             };
 
-            install_dependency(dep, regenerate_remappings).await?;
+            install_dependency(dep, regenerate_remappings, install.recursive_deps).await?;
         }
         Subcommands::Update(update_args) => {
-            let regenerate_remappings = update_args.regenerate_remappings;
-            return update(regenerate_remappings).await;
+            return update(update_args.regenerate_remappings, update_args.recursive_deps).await;
         }
         Subcommands::Login(_) => {
             println!("{}", "🦌 Running Soldeer login 🦌".green());
@@ -200,6 +200,7 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
 async fn install_dependency(
     mut dependency: Dependency,
     regenerate_remappings: bool,
+    recursive_deps: bool,
 ) -> Result<(), SoldeerError> {
     lock_check(&dependency, true)?;
 
@@ -212,7 +213,16 @@ async fn install_dependency(
     };
     add_to_config(&dependency, &config_path)?;
 
-    let result = download_dependency(&dependency, false)
+    let mut config = read_soldeer_config(Some(config_path.clone()))?;
+    if regenerate_remappings {
+        config.remappings_regenerate = regenerate_remappings;
+    }
+
+    if recursive_deps {
+        config.recursive_deps = recursive_deps;
+    }
+
+    let result = download_dependency(&dependency, false, config.recursive_deps)
         .await
         .map_err(|e| SoldeerError::DownloadError { dep: dependency.to_string(), source: e })?;
     match dependency {
@@ -230,11 +240,6 @@ async fn install_dependency(
             cleanup_dependency(&dependency, true)?;
             return Err(SoldeerError::DownloadError { dep: dependency.to_string(), source: e });
         }
-    }
-
-    let mut config = read_soldeer_config(Some(config_path.clone()))?;
-    if regenerate_remappings {
-        config.remappings_regenerate = regenerate_remappings;
     }
 
     janitor::healthcheck_dependency(&dependency)?;
@@ -261,7 +266,7 @@ async fn install_dependency(
     Ok(())
 }
 
-async fn update(regenerate_remappings: bool) -> Result<(), SoldeerError> {
+async fn update(regenerate_remappings: bool, recursive_deps: bool) -> Result<(), SoldeerError> {
     println!("{}", "🦌 Running Soldeer update 🦌".green());
 
     let config_path = get_config_path()?;
@@ -270,9 +275,13 @@ async fn update(regenerate_remappings: bool) -> Result<(), SoldeerError> {
         config.remappings_regenerate = regenerate_remappings;
     }
 
+    if recursive_deps {
+        config.recursive_deps = recursive_deps;
+    }
+
     let mut dependencies: Vec<Dependency> = read_config_deps(None)?;
 
-    let results = download_dependencies(&dependencies, true)
+    let results = download_dependencies(&dependencies, true, config.recursive_deps)
         .await
         .map_err(|e| SoldeerError::DownloadError { dep: String::new(), source: e })?;
 
@@ -363,6 +372,7 @@ libs = ["dependencies"]
             remote_url: None,
             rev: None,
             regenerate_remappings: false,
+            recursive_deps: false,
         });
 
         match run(command) {
@@ -414,6 +424,7 @@ libs = ["dependencies"]
             remote_url: None,
             rev: None,
             regenerate_remappings: false,
+            recursive_deps: false,
         });
 
         match run(command) {
@@ -458,7 +469,8 @@ libs = ["dependencies"]
             env::set_var("base_url", "https://api.soldeer.xyz");
         }
 
-        let command = Subcommands::Update(Update { regenerate_remappings: false });
+        let command =
+            Subcommands::Update(Update { regenerate_remappings: false, recursive_deps: false });
 
         match run(command) {
             Ok(_) => {}
@@ -504,7 +516,8 @@ libs = ["dependencies"]
             env::set_var("base_url", "https://api.soldeer.xyz");
         }
 
-        let command = Subcommands::Update(Update { regenerate_remappings: false });
+        let command =
+            Subcommands::Update(Update { regenerate_remappings: false, recursive_deps: false });
 
         match run(command) {
             Ok(_) => {}
@@ -567,6 +580,7 @@ libs = ["dependencies"]
             remote_url: None,
             rev: None,
             regenerate_remappings: false,
+            recursive_deps: false,
         });
 
         match run(command) {
@@ -756,6 +770,7 @@ libs = ["dependencies"]
             remote_url: Option::None,
             rev: None,
             regenerate_remappings: false,
+            recursive_deps: false,
         });
 
         match run(command) {
@@ -810,7 +825,8 @@ libs = ["dependencies"]
             dependency: Some("forge-std~1.9.1".to_string()),
             remote_url: Some("https://soldeer-revisions.s3.amazonaws.com/forge-std/v1_9_0_03-07-2024_14:44:57_forge-std-v1.9.0.zip".to_string()),
             rev: None,
-            regenerate_remappings: false
+            regenerate_remappings: false,
+            recursive_deps: false
         });
 
         match run(command) {
@@ -866,6 +882,7 @@ libs = ["dependencies"]
             remote_url: Some("https://github.com/foundry-rs/forge-std.git".to_string()),
             rev: None,
             regenerate_remappings: false,
+            recursive_deps: false,
         });
 
         match run(command) {
@@ -921,6 +938,7 @@ libs = ["dependencies"]
             remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
             rev: None,
             regenerate_remappings: false,
+            recursive_deps: false,
         });
 
         match run(command) {
@@ -976,6 +994,7 @@ libs = ["dependencies"]
             remote_url: Some("git@github.com:foundry-rs/forge-std.git".to_string()),
             rev: Some("3778c3cb8e4244cb5a1c3ef3ce1c71a3683e324a".to_string()),
             regenerate_remappings: false,
+            recursive_deps: false,
         });
 
         match run(command) {

--- a/tests/ci/foundry.rs
+++ b/tests/ci/foundry.rs
@@ -25,6 +25,7 @@ fn soldeer_install_valid_dependency() {
         remote_url: None,
         rev: None,
         regenerate_remappings: false,
+        recursive_deps: false,
     });
 
     match soldeer::run(command) {


### PR DESCRIPTION
Solves the recursive dependencies.

if you set --recursive-deps when you run install or update  or you set the config
[soldeer]
recursive-deps = true

Soldeer will install automatically the submodule dependencies and soldeer dependencies of the dependency you want to install. 

Closes https://github.com/mario-eth/soldeer/issues/115