### PR TITLE
chore: remove unused dev dep env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,29 +429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,12 +685,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1634,7 +1605,6 @@ dependencies = [
  "clap",
  "const-hex",
  "email-address-parser",
- "env_logger",
  "futures",
  "ignore",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ zip = { version = "2.1.3", default-features = false, features = ["deflate"] }
 zip-extract = "0.1.3"
 
 [dev-dependencies]
-env_logger = "0.11.3"
 mockito = "1.4.0"
 rand = "0.8.5"
 serial_test = "3.1.1"
@@ -65,6 +64,3 @@ path = "src/main.rs"
 [features]
 default = ["rustls"]
 rustls = ["reqwest/rustls-tls"]
-
-[profile.test]
-opt-level = 2


### PR DESCRIPTION
Also removing
```
[profile.test]
opt-level = 2
```
as it does not speed up tests meaningfully and causes a recompilation between `cargo build` and `cargo test`.