### PR TITLE
fix(utils): always consider relative path in hashing

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -214,9 +214,7 @@ pub fn hash_folder(
             // first hash the filename/dirname to make sure it can't be renamed or removed
             let mut hasher = <Sha256 as Digest>::new();
             hasher.update(
-                path.canonicalize()
-                    .expect("path should be canonicalizable")
-                    .strip_prefix(root_path.as_ref())
+                path.strip_prefix(root_path.as_ref())
                     .expect("path should be a child of root")
                     .to_string_lossy()
                     .as_bytes(),


### PR DESCRIPTION
Previously, the `hash_folder` function was not properly normalizing paths to be relative to the root of the considered directory. This lead to hash inconsistencies between environments. It didn't show up in unit tests because the input path was itself relative. A new test has been added that shows the now correct behavior.