### PR TITLE
refactor!: minor refactor and integration tests

### DIFF
--- a/crates/commands/src/commands/mod.rs
+++ b/crates/commands/src/commands/mod.rs
@@ -13,11 +13,12 @@ pub mod update;
 #[clap(name = "soldeer", author = "m4rio.eth", version)]
 pub struct Args {
     #[clap(subcommand)]
-    pub command: Subcommands,
+    pub command: Command,
 }
 
+/// The available commands for Soldeer
 #[derive(Debug, Clone, Subcommand, From)]
-pub enum Subcommands {
+pub enum Command {
     Init(init::Init),
     Install(install::Install),
     Update(update::Update),
@@ -27,13 +28,13 @@ pub enum Subcommands {
     Version(Version),
 }
 
+/// Display the version of Soldeer
+#[derive(Debug, Clone, Default, Parser)]
+pub struct Version {}
+
 fn validate_dependency(dep: &str) -> std::result::Result<String, String> {
     if dep.split('~').count() != 2 {
         return Err("The dependency should be in the format <DEPENDENCY>~<VERSION>".to_string());
     }
     Ok(dep.to_string())
 }
-
-/// Display the version of Soldeer
-#[derive(Debug, Clone, Default, Parser)]
-pub struct Version {}

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -1,16 +1,16 @@
 //! High-level commands for the Soldeer CLI
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-pub use crate::commands::{Args, Subcommands};
+pub use crate::commands::{Args, Command};
 use cliclack::{intro, log::step, outro, outro_cancel};
 use soldeer_core::{config::Paths, Result};
 use std::env;
 
 pub mod commands;
 
-pub async fn run(command: Subcommands) -> Result<()> {
+pub async fn run(command: Command) -> Result<()> {
     let paths = Paths::new()?;
     match command {
-        Subcommands::Init(init) => {
+        Command::Init(init) => {
             intro("🦌 Soldeer Init 🦌")?;
             step("Initialize Foundry project to use Soldeer")?;
             commands::init::init_command(&paths, init).await.inspect_err(|_| {
@@ -18,42 +18,42 @@ pub async fn run(command: Subcommands) -> Result<()> {
             })?;
             outro("Done initializing!")?;
         }
-        Subcommands::Install(cmd) => {
+        Command::Install(cmd) => {
             intro("🦌 Soldeer Install 🦌")?;
             commands::install::install_command(&paths, cmd).await.inspect_err(|_| {
                 outro_cancel("An error occurred during install").ok();
             })?;
             outro("Done installing!")?;
         }
-        Subcommands::Update(cmd) => {
+        Command::Update(cmd) => {
             intro("🦌 Soldeer Update 🦌")?;
             commands::update::update_command(&paths, cmd).await.inspect_err(|_| {
                 outro_cancel("An error occurred during the update").ok();
             })?;
             outro("Done updating!")?;
         }
-        Subcommands::Uninstall(cmd) => {
+        Command::Uninstall(cmd) => {
             intro("🦌 Soldeer Uninstall 🦌")?;
             commands::uninstall::uninstall_command(&paths, &cmd).inspect_err(|_| {
                 outro_cancel("An error occurred during uninstall").ok();
             })?;
             outro("Done uninstalling!")?;
         }
-        Subcommands::Login(_) => {
+        Command::Login(_) => {
             intro("🦌 Soldeer Login 🦌")?;
             commands::login::login_command().await.inspect_err(|_| {
                 outro_cancel("An error occurred during login").ok();
             })?;
             outro("Done logging in!")?;
         }
-        Subcommands::Push(cmd) => {
+        Command::Push(cmd) => {
             intro("🦌 Soldeer Push 🦌")?;
             commands::push::push_command(cmd).await.inspect_err(|_| {
                 outro_cancel("An error occurred during push").ok();
             })?;
             outro("Done!")?;
         }
-        Subcommands::Version(_) => {
+        Command::Version(_) => {
             const VERSION: &str = env!("CARGO_PKG_VERSION");
             println!("soldeer {VERSION}");
         }

--- a/crates/commands/tests/tests-init.rs
+++ b/crates/commands/tests/tests-init.rs
@@ -1,4 +1,4 @@
-use soldeer_commands::{commands::init::Init, run, Subcommands};
+use soldeer_commands::{commands::init::Init, run, Command};
 use soldeer_core::{config::read_config_deps, lock::read_lockfile, utils::run_git_command};
 use std::fs;
 use temp_env::async_with_vars;
@@ -14,7 +14,7 @@ async fn test_init_clean() {
     .await
     .unwrap();
     fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
-    let cmd: Subcommands = Init { clean: true }.into();
+    let cmd: Command = Init { clean: true }.into();
     let res =
         async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
             .await;
@@ -42,7 +42,7 @@ async fn test_init_no_clean() {
     .await
     .unwrap();
     fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
-    let cmd: Subcommands = Init { clean: false }.into();
+    let cmd: Command = Init { clean: false }.into();
     let res =
         async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
             .await;
@@ -75,7 +75,7 @@ remappings_generate = false
 [dependencies]
 ";
     fs::write(dir.join("soldeer.toml"), contents).unwrap();
-    let cmd: Subcommands = Init { clean: true }.into();
+    let cmd: Command = Init { clean: true }.into();
     let res =
         async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
             .await;
@@ -94,7 +94,7 @@ async fn test_init_no_gitignore() {
     .unwrap();
     fs::remove_file(dir.join(".gitignore")).unwrap();
     fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
-    let cmd: Subcommands = Init { clean: true }.into();
+    let cmd: Command = Init { clean: true }.into();
     let res =
         async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
             .await;

--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -1,0 +1,197 @@
+use soldeer_commands::{commands::install::Install, run, Command};
+use soldeer_core::{config::read_config_deps, lock::read_lockfile};
+use std::{fs, path::Path};
+use temp_env::async_with_vars;
+use testdir::testdir;
+
+fn check_install(dir: &Path, name: &str, version_req: &str) {
+    assert!(dir.join("dependencies").exists());
+    let deps = read_config_deps(dir.join("soldeer.toml")).unwrap();
+    assert_eq!(deps.first().unwrap().name(), name);
+    let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
+    assert!(remappings.contains(name));
+    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    assert_eq!(lock.entries.first().unwrap().name(), name);
+    let version = lock.entries.first().unwrap().version();
+    assert!(version.starts_with(version_req));
+    assert!(dir.join("dependencies").join(format!("{name}-{version}")).exists());
+}
+
+#[tokio::test]
+async fn test_install_registry_any_version() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install {
+        dependency: Some("@openzeppelin-contracts~5".to_string()),
+        remote_url: None,
+        rev: None,
+        tag: None,
+        branch: None,
+        regenerate_remappings: false,
+        recursive_deps: false,
+        clean: false,
+    }
+    .into();
+    let res =
+        async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
+            .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "@openzeppelin-contracts", "5");
+}
+
+#[tokio::test]
+async fn test_install_registry_specific_version() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install {
+        dependency: Some("@openzeppelin-contracts~4.9.5".to_string()),
+        remote_url: None,
+        rev: None,
+        tag: None,
+        branch: None,
+        regenerate_remappings: false,
+        recursive_deps: false,
+        clean: false,
+    }
+    .into();
+    let res =
+        async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
+            .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "@openzeppelin-contracts", "4.9.5");
+}
+
+#[tokio::test]
+async fn test_install_custom_http() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install {
+        dependency: Some("mylib~1.0.0".to_string()),
+        remote_url: Some("https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip".to_string()),
+        rev: None,
+        tag: None,
+        branch: None,
+        regenerate_remappings: false,
+        recursive_deps: false,
+        clean: false,
+    }
+    .into();
+    let res =
+        async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
+            .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "mylib", "1.0.0");
+    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    assert_eq!(
+        lock.entries.first().unwrap().as_http().unwrap().url,
+        "https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip"
+    );
+}
+
+#[tokio::test]
+async fn test_install_git_main() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install {
+        dependency: Some("mylib~0.1.0".to_string()),
+        remote_url: Some("https://github.com/beeb/test-repo.git".to_string()),
+        rev: None,
+        tag: None,
+        branch: None,
+        regenerate_remappings: false,
+        recursive_deps: false,
+        clean: false,
+    }
+    .into();
+    let res =
+        async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
+            .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "mylib", "0.1.0");
+    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    assert_eq!(
+        lock.entries.first().unwrap().as_git().unwrap().rev,
+        "d5d72fa135d28b2e8307650b3ea79115183f2406"
+    );
+}
+
+#[tokio::test]
+async fn test_install_git_commit() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install {
+        dependency: Some("mylib~0.1.0".to_string()),
+        remote_url: Some("https://github.com/beeb/test-repo.git".to_string()),
+        rev: Some("78c2f6a1a54db26bab6c3f501854a1564eb3707f".to_string()),
+        tag: None,
+        branch: None,
+        regenerate_remappings: false,
+        recursive_deps: false,
+        clean: false,
+    }
+    .into();
+    let res =
+        async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
+            .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "mylib", "0.1.0");
+    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    assert_eq!(
+        lock.entries.first().unwrap().as_git().unwrap().rev,
+        "78c2f6a1a54db26bab6c3f501854a1564eb3707f"
+    );
+}
+
+#[tokio::test]
+async fn test_install_git_tag() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install {
+        dependency: Some("mylib~0.1.0".to_string()),
+        remote_url: Some("https://github.com/beeb/test-repo.git".to_string()),
+        rev: None,
+        tag: Some("v0.1.0".to_string()),
+        branch: None,
+        regenerate_remappings: false,
+        recursive_deps: false,
+        clean: false,
+    }
+    .into();
+    let res =
+        async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
+            .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "mylib", "0.1.0");
+    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    assert_eq!(
+        lock.entries.first().unwrap().as_git().unwrap().rev,
+        "78c2f6a1a54db26bab6c3f501854a1564eb3707f"
+    );
+}
+
+#[tokio::test]
+async fn test_install_git_branch() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install {
+        dependency: Some("mylib~dev".to_string()),
+        remote_url: Some("https://github.com/beeb/test-repo.git".to_string()),
+        rev: None,
+        tag: None,
+        branch: Some("dev".to_string()),
+        regenerate_remappings: false,
+        recursive_deps: false,
+        clean: false,
+    }
+    .into();
+    let res =
+        async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
+            .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "mylib", "dev");
+    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    assert_eq!(
+        lock.entries.first().unwrap().as_git().unwrap().rev,
+        "8d903e557e8f1b6e62bde768aa456d4ddfca72c4"
+    );
+}

--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -266,6 +266,7 @@ mylib = "1.1"
     let zip_file = download_file(
         "https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip",
         dir.join(".tmp"),
+        "tmp",
     )
     .await
     .unwrap();

--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -262,15 +262,16 @@ mylib = "1.1"
 "#;
     fs::write(dir.join("soldeer.toml"), contents).unwrap();
 
-    fs::create_dir(dir.join(".tmp")).unwrap();
+    // get zip file locally for mock
     let zip_file = download_file(
         "https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip",
-        dir.join(".tmp"),
+        &dir,
         "tmp",
     )
     .await
     .unwrap();
 
+    // serve the file with mock server
     let mut server = mockito::Server::new_async().await;
     let mock = server.mock("GET", "/file.zip").with_body_from_file(zip_file).create_async().await;
     let mock = mock.expect(1); // download link should be called exactly once

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -404,7 +404,7 @@ async fn install_dependency_inner(
             let zip_path = download_file(
                 &dep.url,
                 path.parent().expect("dependency install path should have a parent"),
-                &dep.name,
+                &format!("{}-{}", dep.name, dep.version),
             )
             .await?;
             #[cfg(feature = "cli")]


### PR DESCRIPTION
Took the chance to refactor the `download_file` function and its usage, because it was not exactly behaving as described in the docs. Now the zip files are downloaded in the `dependencies` folder with the name of the dependency and the zip extension.

Also renammed the `Subcommands` enum to `Command` (because enum should be singular and it's shorter).