### PR TITLE
feat(commands): update libs in foundry config during init

### DIFF
--- a/crates/commands/src/commands/init.rs
+++ b/crates/commands/src/commands/init.rs
@@ -4,7 +4,7 @@ use cliclack::{
     multi_progress,
 };
 use soldeer_core::{
-    config::{add_to_config, read_soldeer_config, Paths},
+    config::{add_to_config, read_soldeer_config, update_config_libs, Paths},
     install::{ensure_dependencies_dir, install_dependency, Progress},
     lock::add_to_lockfile,
     registry::get_latest_version,
@@ -45,6 +45,10 @@ pub(crate) async fn init_command(paths: &Paths, cmd: Init) -> Result<()> {
     progress.stop_all();
     multi.stop();
     add_to_config(&dependency, &paths.config)?;
+    let foundry_config = paths.root.join("foundry.toml");
+    if foundry_config.exists() {
+        update_config_libs(foundry_config)?;
+    }
     success("Dependency added to config")?;
     add_to_lockfile(lock, &paths.lock)?;
     success("Dependency added to lockfile")?;

--- a/crates/commands/tests/tests-init.rs
+++ b/crates/commands/tests/tests-init.rs
@@ -30,6 +30,8 @@ async fn test_init_clean() {
     assert!(remappings.contains("forge-std"));
     let gitignore = fs::read_to_string(dir.join(".gitignore")).unwrap();
     assert!(gitignore.contains("/dependencies"));
+    let foundry_config = fs::read_to_string(dir.join("foundry.toml")).unwrap();
+    assert!(foundry_config.contains("libs = [\"dependencies\"]"));
 }
 
 #[tokio::test]
@@ -58,6 +60,8 @@ async fn test_init_no_clean() {
     assert!(remappings.contains("forge-std"));
     let gitignore = fs::read_to_string(dir.join(".gitignore")).unwrap();
     assert!(gitignore.contains("/dependencies"));
+    let foundry_config = fs::read_to_string(dir.join("foundry.toml")).unwrap();
+    assert!(foundry_config.contains("libs = [\"dependencies\"]"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
The `init` command now adds the "dependencies" folder to the `profile.default.libs` foundry config item if the foundry.toml file exists.