### PR TITLE
Lock-free synchronization, parallelize cpu bound tasks, add rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "email-address-parser"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1187,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1566,7 @@ dependencies = [
  "mockito",
  "path-slash",
  "rand",
+ "rayon",
  "regex",
  "reqwest",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ zip-extract = { version = "0.2.1", default-features = false, features = [
 ] }
 dunce = "1.0.5"
 path-slash = "0.2.1"
+rayon = "1.10.0"
 
 [dev-dependencies]
 mockito = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ use std::{env, path::PathBuf, sync::LazyLock};
 use utils::{get_url_type, UrlType};
 use versioning::validate_name;
 use yansi::Paint as _;
-
 mod auth;
 pub mod commands;
 mod config;
@@ -130,10 +129,10 @@ pub async fn run(command: Subcommands) -> Result<(), SoldeerError> {
             let skip_warnings = push.skip_warnings;
 
             // Check for sensitive files or directories
-            if !dry_run &&
-                !skip_warnings &&
-                check_dotfiles_recursive(&path) &&
-                !prompt_user_for_confirmation()
+            if !dry_run
+                && !skip_warnings
+                && check_dotfiles_recursive(&path)
+                && !prompt_user_for_confirmation()
             {
                 println!("{}", "Push operation aborted by the user.".yellow());
                 return Ok(());
@@ -1809,8 +1808,8 @@ recursive_deps = true
     fn find_forge_std_path() -> PathBuf {
         for entry in fs::read_dir(DEPENDENCY_DIR.clone()).unwrap().filter_map(Result::ok) {
             let path = entry.path();
-            if path.is_dir() &&
-                path.file_name().unwrap().to_string_lossy().starts_with("forge-std-")
+            if path.is_dir()
+                && path.file_name().unwrap().to_string_lossy().starts_with("forge-std-")
             {
                 return path;
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -250,7 +250,7 @@ pub fn hash_folder(
         })
     });
     drop(tx);
-    let mut hashes = hashes.join().unwrap();
+    let mut hashes = hashes.join().expect("Failed to join thread");
     let mut hasher = <Sha256 as Digest>::new();
     hashes.par_sort_unstable();
     // hash the hashes (yo dawg...)

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -143,7 +143,7 @@ fn filter_files_to_copy(root_directory_path: impl AsRef<Path>) -> Vec<PathBuf> {
         })
     });
     drop(tx);
-    files_to_copy.join().unwrap()
+    files_to_copy.join().expect("Failed to join thread")
 }
 
 async fn push_to_repo(

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -15,7 +15,7 @@ use std::{
     fs::{remove_file, File},
     io::{self, Read, Write},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 use yansi::Paint as _;
 use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
@@ -111,13 +111,23 @@ fn zip_file(
 }
 
 fn filter_files_to_copy(root_directory_path: impl AsRef<Path>) -> Vec<PathBuf> {
-    let files_to_copy = Arc::new(Mutex::new(Vec::with_capacity(100)));
+    let (tx, rx) = std::sync::mpsc::channel::<PathBuf>();
+    let tx = Arc::new(tx);
+
+    let files_to_copy = std::thread::spawn(move || {
+        let mut files = Vec::new();
+        while let Ok(path) = rx.recv() {
+            files.push(path);
+        }
+        files
+    });
+
     let walker = WalkBuilder::new(root_directory_path)
         .add_custom_ignore_filename(".soldeerignore")
         .hidden(false)
         .build_parallel();
     walker.run(|| {
-        let files_to_copy = Arc::clone(&files_to_copy);
+        let tx = Arc::clone(&tx);
         // function executed for each DirEntry
         Box::new(move |result| {
             let Ok(entry) = result else {
@@ -127,16 +137,13 @@ fn filter_files_to_copy(root_directory_path: impl AsRef<Path>) -> Vec<PathBuf> {
             if path.is_dir() {
                 return WalkState::Continue;
             }
-            let mut files_to_copy = files_to_copy.lock().expect("mutex should not be poisoned");
-            files_to_copy.push(path.to_path_buf());
+            tx.send(path.to_path_buf())
+                .expect("Channel receiver should never be dropped before end of function scope");
             WalkState::Continue
         })
     });
-
-    Arc::into_inner(files_to_copy)
-        .expect("Arc should have no other strong references")
-        .into_inner()
-        .expect("mutex should not be poisoned")
+    drop(tx);
+    files_to_copy.join().unwrap()
 }
 
 async fn push_to_repo(


### PR DESCRIPTION
- Fixes use of Arc<Mutex<T>> -- the performance of locks degrade with contention (each thread trying to insert data into Vec<T>). An MPSC channel solves this since it uses a FIFO queue internally to asynchronously receive T by each directory thread. 
- Parallelized a few calls to `.sort_unstable()` and `.sort_unstable_by()`
- Parallelized O(N) operations like `.position_any()`, `.any()`
- Parallelized `write_lock()`
- Unnecessary SeqCst usage changed in favor of Acq + Rel memory orderings