### PR TITLE
ci: speed up test by using cargo-nextest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,10 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run tests
-        run: cargo test
+        run: cargo nextest run
 
   doctests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Slightly faster tests in CI (at least on macOS and Linux). I expect the more tests we have, the more benefit we will have from nextest.