### PR TITLE
fix(core): `path_matches` semver comparison

### DIFF
--- a/crates/commands/tests/tests-update.rs
+++ b/crates/commands/tests/tests-update.rs
@@ -51,7 +51,7 @@ async fn test_update_existing() {
     let version = lockfile.entries.first().unwrap().version();
     assert_ne!(version, "1.9.0");
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
-    assert_eq!(remappings, format!("forge-std-1/=dependencies/forge-std-1.9.2/\n"));
+    assert_eq!(remappings, format!("forge-std-1/=dependencies/forge-std-{version}/\n"));
     assert!(dir.join("dependencies").join(format!("forge-std-{version}")).exists());
 }
 
@@ -196,8 +196,4 @@ remappings_location = "config"
         async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
             .await;
     assert!(res.is_ok(), "{res:?}");
-    let lockfile = read_lockfile(dir.join("soldeer.lock")).unwrap();
-    let version = lockfile.entries.first().unwrap().version();
-    assert_ne!(version, "1.9.0");
-    assert!(dir.join("dependencies").join(format!("forge-std-{version}")).exists());
 }

--- a/crates/commands/tests/tests-update.rs
+++ b/crates/commands/tests/tests-update.rs
@@ -196,4 +196,11 @@ remappings_location = "config"
         async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
             .await;
     assert!(res.is_ok(), "{res:?}");
+    let deps = dir.join("dependencies");
+    assert!(deps.join("@tt-1.6.1").exists());
+    assert!(deps.join("forge-std-1.8.1").exists());
+    assert!(deps.join("solmate-6.7.0").exists());
+    assert!(deps.join("mario-1.0").exists());
+    assert!(deps.join("mario-custom-tag-1.0").exists());
+    assert!(deps.join("mario-custom-branch-1.0").exists());
 }


### PR DESCRIPTION
`path_matches` should only attempt to match a version to a version requirement if both can be parsed.