### PR TITLE
fix(core): accept wildcard (star) version

### DIFF
--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -38,6 +38,18 @@ async fn test_install_registry_any_version() {
 }
 
 #[tokio::test]
+async fn test_install_registry_wildcard() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install::builder().dependency("solady~*").build().into();
+    let res =
+        async_with_vars([("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))], run(cmd))
+            .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "solady", "");
+}
+
+#[tokio::test]
 async fn test_install_registry_specific_version() {
     let dir = testdir!();
     fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -259,7 +259,7 @@ pub fn parse_version_req(version_req: &str) -> Option<VersionReq> {
         return None;
     };
     if req.comparators.is_empty() {
-        return None;
+        return Some(req); // wildcard/any version
     }
     let orig_items: Vec<_> = version_req.split(',').collect();
     // we only perform the operator conversion if we can reference the original string, i.e. if the
@@ -477,5 +477,6 @@ mod tests {
         assert_eq!(parse_version_req(">=1.9.0"), Some(VersionReq::parse(">=1.9.0").unwrap()));
         assert_eq!(parse_version_req(""), None);
         assert_eq!(parse_version_req("foobar"), None);
+        assert_eq!(parse_version_req("*"), Some(VersionReq::STAR));
     }
 }


### PR DESCRIPTION
Previously, the `parse_version_req` function didn't accept `*` as a valid version requirement string. This has now changed and it is accepted, meaning `>=0.0.0`.

Note: this wildcard version requirement does not match pre-release versions.

Closes #223 