### PR TITLE
fix(push): ensure version is non-empty when pushing to registry

### DIFF
--- a/crates/commands/src/commands/push.rs
+++ b/crates/commands/src/commands/push.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use cliclack::log::{info, remark, warning};
 use soldeer_core::{
     errors::PublishError,
-    push::{filter_ignored_files, push_version, validate_name},
+    push::{filter_ignored_files, push_version, validate_name, validate_version},
     utils::check_dotfiles,
     Result,
 };
@@ -75,6 +75,7 @@ pub(crate) async fn push_command(cmd: Push) -> Result<()> {
         cmd.dependency.split_once('~').expect("dependency string should have name and version");
 
     validate_name(dependency_name)?;
+    validate_version(dependency_version)?;
 
     if let Some(zip_path) =
         push_version(dependency_name, dependency_version, path, &files_to_copy, cmd.dry_run).await?

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -220,6 +220,9 @@ pub enum PublishError {
     #[error("invalid package name, only alphanumeric characters, `-` and `@` are allowed. Length must be between 3 and 100 characters")]
     InvalidName,
 
+    #[error("package version cannot be empty")]
+    EmptyVersion,
+
     #[error("user cancelled operation")]
     UserAborted,
 

--- a/crates/core/src/push.rs
+++ b/crates/core/src/push.rs
@@ -81,6 +81,13 @@ pub fn validate_name(name: &str) -> Result<()> {
     Ok(())
 }
 
+pub fn validate_version(version: &str) -> Result<()> {
+    if version.is_empty() {
+        return Err(PublishError::EmptyVersion);
+    }
+    Ok(())
+}
+
 /// Create a zip file from a list of files.
 ///
 /// The zip file will be created in the root directory, with the provided name and the `.zip`
@@ -267,6 +274,11 @@ mod tests {
         assert!(validate_name("foo.bar").is_err());
         assert!(validate_name("mypäckage").is_err());
         assert!(validate_name(&"a".repeat(101)).is_err());
+    }
+
+    #[test]
+    fn test_empty_version() {
+        assert!(validate_version("").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #246 

I have decided to introduce a wrapper around validating version of the package for the push command rather than inlining it with the intent that perhaps in the future semver could be enforced, or other validation performed.