### PR TITLE
fix(registry): version resolution when no SemVer

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -224,7 +224,8 @@ pub async fn get_all_versions_descending(dependency_name: &str) -> Result<Versio
 
 /// Get the latest version of a dependency that satisfies the version requirement.
 ///
-/// If the API response contains non-semver-compliant versions, then we attempt to find an exact match for the requirement, or error out.
+/// If the API response contains non-semver-compliant versions, then we attempt to find an exact
+/// match for the requirement, or error out.
 pub async fn get_latest_supported_version(dependency: &Dependency) -> Result<String> {
     debug!(dep:% = dependency, version_req = dependency.version_req(); "retrieving latest version according to version requirement");
     match get_all_versions_descending(dependency.name()).await? {
@@ -253,7 +254,8 @@ pub async fn get_latest_supported_version(dependency: &Dependency) -> Result<Str
             }
         }
         Versions::NonSemver(all_versions) => {
-            // try to find the exact version specifier in the list of all versions, otherwise error out
+            // try to find the exact version specifier in the list of all versions, otherwise error
+            // out
             debug!(dep:% = dependency; "versions are not all semver compliant, trying to find exact match");
             all_versions.into_iter().find(|v| v == dependency.version_req()).ok_or_else(|| {
                 RegistryError::NoMatchingVersion {

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -224,7 +224,7 @@ pub async fn get_all_versions_descending(dependency_name: &str) -> Result<Versio
 
 /// Get the latest version of a dependency that satisfies the version requirement.
 ///
-/// If the version requirement is not semver-compliant, then we attempt to find an exact match for the requirement, or error out.
+/// If the API response contains non-semver-compliant versions, then we attempt to find an exact match for the requirement, or error out.
 pub async fn get_latest_supported_version(dependency: &Dependency) -> Result<String> {
     debug!(dep:% = dependency, version_req = dependency.version_req(); "retrieving latest version according to version requirement");
     match get_all_versions_descending(dependency.name()).await? {

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -224,8 +224,7 @@ pub async fn get_all_versions_descending(dependency_name: &str) -> Result<Versio
 
 /// Get the latest version of a dependency that satisfies the version requirement.
 ///
-/// If the version requirement is not semver-compliant, then the latest version is the one with the
-/// latest creation date.
+/// If the version requirement is not semver-compliant, then we attempt to find an exact match for the requirement, or error out.
 pub async fn get_latest_supported_version(dependency: &Dependency) -> Result<String> {
     debug!(dep:% = dependency, version_req = dependency.version_req(); "retrieving latest version according to version requirement");
     match get_all_versions_descending(dependency.name()).await? {

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -471,14 +471,23 @@ mod tests {
             .await;
 
         let dependency: Dependency =
-            HttpDependency::builder().name("forge-std").version_req("foobar").build().into();
+            HttpDependency::builder().name("forge-std").version_req("2024-06").build().into();
         let res = async_with_vars(
             [("SOLDEER_API_URL", Some(server.url()))],
             get_latest_supported_version(&dependency),
         )
         .await;
         assert!(res.is_ok(), "{res:?}");
-        assert_eq!(res.unwrap(), "2024-08");
+        assert_eq!(res.unwrap(), "2024-06"); // should resolve to the exact match
+
+        let dependency: Dependency =
+            HttpDependency::builder().name("forge-std").version_req("non-existant").build().into();
+        let res = async_with_vars(
+            [("SOLDEER_API_URL", Some(server.url()))],
+            get_latest_supported_version(&dependency),
+        )
+        .await;
+        assert!(matches!(res, Err(RegistryError::NoMatchingVersion { .. })));
     }
 
     #[test]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/mario-eth/soldeer/blob/main/CONTRIBUTING.md

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(core): missing validation for ...
    - docs(commands): update doc-comments for command ...
    - feat(core): add option to ...

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text ("Closes #123").
3. Ensure there are tests that cover the changes.
4. Ensure `cargo nextest run` passes.
5. Ensure code is formatted with `cargo +nightly fmt -- --check`.
6. Ensure `cargo +nightly clippy --all --all-targets --all-features -- -D warnings` passes.
7. Open as a draft PR if your work is still in progress.
-->

Previously, if some versions in the API response could not be parsed as SemVer, the resolution would default to using the latest version. Now, this creates and error unless we can find an exact match for the version specifier of the dependency.
