### PR TITLE
chore: make release-plz use a single tag

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 dependencies_update = true
 git_release_enable = false        # we only need to create a git tag for one of the crates
+git_tag_enable = false
 publish = false                   # cargo publish will be done by hand for now
 changelog_path = "./CHANGELOG.md"
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,6 +17,7 @@ name = "soldeer"
 version_group = "soldeer"
 git_tag_enable = true
 git_release_enable = true
+git_tag_name = "v{{ version }}"
 
 [changelog]
 body = """


### PR DESCRIPTION
Release-plz uses by a default a tag which is prefixed with the crate name, but we don't need this as all crates have the same version number in sync.

https://release-plz.dev/docs/extra/single-tag