### PR TITLE
fix(core): recursive subdependencies install

### DIFF
--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -405,16 +405,12 @@ async fn test_install_recursive_deps_nested() {
     .await;
     assert!(res.is_ok(), "{res:?}");
     let paths = [
-        "@uniswap-permit2-1.0.0",
-        "@uniswap-permit2-1.0.0/lib/forge-gas-snapshot",
-        "@uniswap-permit2-1.0.0/lib/forge-std",
-        "@uniswap-permit2-1.0.0/lib/openzeppelin-contracts",
-        "@uniswap-permit2-1.0.0/lib/solmate",
-        "@uniswap-permit2-1.0.0/lib/forge-gas-snapshot/dependencies/forge-std-1.9.2",
-        "@uniswap-permit2-1.0.0/lib/openzeppelin-contracts/lib/erc4626-tests",
-        "@uniswap-permit2-1.0.0/lib/openzeppelin-contracts/lib/forge-std",
-        "@uniswap-permit2-1.0.0/lib/openzeppelin-contracts/lib/halmos-cheatcodes",
-        "@uniswap-permit2-1.0.0/lib/solmate/lib/ds-test",
+        "@uniswap-permit2-1.0.0/lib/forge-std/src",
+        "@uniswap-permit2-1.0.0/lib/forge-gas-snapshot/dependencies/forge-std-1.9.2/src",
+        "@uniswap-permit2-1.0.0/lib/openzeppelin-contracts/lib/erc4626-tests/ERC4626.test.sol",
+        "@uniswap-permit2-1.0.0/lib/openzeppelin-contracts/lib/forge-std/src",
+        "@uniswap-permit2-1.0.0/lib/openzeppelin-contracts/lib/halmos-cheatcodes/src",
+        "@uniswap-permit2-1.0.0/lib/solmate/lib/ds-test/src",
     ];
     for path in paths {
         let dep_path = dir.join("dependencies").join(path);

--- a/crates/core/src/download.rs
+++ b/crates/core/src/download.rs
@@ -61,7 +61,7 @@ pub async fn unzip_file(path: impl AsRef<Path>, into: impl AsRef<Path>) -> Resul
     tokio::fs::remove_file(&path)
         .await
         .map_err(|e| DownloadError::IOError { path: path.clone(), source: e })?;
-    debug!(path:? = path; "removed zip file");
+    debug!(path:?; "removed zip file");
     Ok(())
 }
 
@@ -145,9 +145,9 @@ pub async fn find_install_path(dependency: &Dependency, deps: impl AsRef<Path>) 
         if !path.is_dir() {
             continue;
         }
-        trace!(path:? = path; "found folder in deps");
+        trace!(path:?; "found folder in deps");
         if install_path_matches(dependency, &path) {
-            debug!(path:? = path, dep:% = dependency; "folder name matches dependency");
+            debug!(path:?, dep:% = dependency; "folder name matches dependency");
             return Some(path);
         }
     }
@@ -181,7 +181,7 @@ pub async fn delete_dependency_files(
 fn install_path_matches(dependency: &Dependency, path: impl AsRef<Path>) -> bool {
     let path = path.as_ref();
     if !path.is_dir() {
-        trace!(path:? = path; "path is not a directory");
+        trace!(path:?; "path is not a directory");
         return false;
     }
     path_matches(dependency, path)

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -112,8 +112,8 @@ pub enum DownloadError {
     #[error("error extracting dependency: {0}")]
     UnzipError(#[from] zip_extract::ZipExtractError),
 
-    #[error("error during git operation: {0}")]
-    GitError(String),
+    #[error("error during git command {args:?}: {message}")]
+    GitError { message: String, args: Vec<String> },
 
     #[error("error during IO operation for {path:?}: {source}")]
     IOError { path: PathBuf, source: io::Error },

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -255,11 +255,9 @@ impl From<LockEntry> for InstallInfo {
 }
 
 /// Git submodule information
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, bon::Builder)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 struct Submodule<'a> {
-    #[builder(default)]
     url: &'a str,
-    #[builder(default)]
     path: &'a str,
     branch: Option<&'a str>,
 }

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -656,7 +656,7 @@ async fn get_submodules(path: &PathBuf) -> Result<HashMap<String, Submodule>> {
 /// Re-add submodules found in a `.gitmodules` when the folder has to be re-initialized as a git
 /// repo.
 ///
-/// The file is parsed, and each module is added again with `git submodules add`.
+/// The file is parsed, and each module is added again with `git submodule add`.
 async fn reinit_submodules(path: &PathBuf) -> Result<Vec<PathBuf>> {
     debug!(path:?; "running git init");
     run_git_command(&["init"], Some(path)).await?;

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -581,6 +581,8 @@ async fn install_subdependencies(path: impl AsRef<Path>) -> Result<()> {
         if fs::metadata(path.join(".git")).await.is_ok() {
             debug!(path:?; "subdependency contains .git directory, cloning submodules");
             run_git_command(&["submodule", "update", "--init"], Some(&path)).await?;
+            // we need to recurse into each of the submodules to ensure any soldeer sub-deps of
+            // those are also installed
             let submodules = get_submodules(&path).await?;
             for (_, submodule) in submodules {
                 let sub_path = path.join(submodule.path);
@@ -590,6 +592,8 @@ async fn install_subdependencies(path: impl AsRef<Path>) -> Result<()> {
         } else {
             debug!(path:?; "subdependency has git submodules configuration but is not a git repository");
             let submodule_paths = reinit_submodules(&path).await?;
+            // we need to recurse into each of the submodules to ensure any soldeer sub-deps of
+            // those are also installed
             for sub_path in submodule_paths {
                 debug!(sub_path:?; "recursing into the git submodule");
                 Box::pin(install_subdependencies(sub_path)).await?;

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -675,8 +675,6 @@ async fn reinit_submodules(path: &PathBuf) -> Result<Vec<PathBuf>> {
         debug!(submodule_name, path:?; "added submodule");
         out.push(path.join(submodule.path));
     }
-    // debug!(path:?; "making sure submodules are recursively updated");
-    // run_git_command(&["submodule", "update", "--init", "--recursive"], Some(path)).await?;
     Ok(out)
 }
 

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -664,7 +664,12 @@ async fn reinit_submodules(path: &PathBuf) -> Result<Vec<PathBuf>> {
     debug!(submodules:?, path:?; "got submodules config");
     let mut out = Vec::new();
     for (submodule_name, submodule) in submodules {
-        let mut args = vec!["submodule", "add", "--name", &submodule_name];
+        // make sure to remove the path if it already exists
+        let dest_path = path.join(&submodule.path);
+        fs::remove_dir_all(&dest_path)
+            .await
+            .map_err(|e| InstallError::IOError { path: dest_path, source: e })?;
+        let mut args = vec!["submodule", "add", "-f", "--name", &submodule_name];
         if let Some(branch) = &submodule.branch {
             args.push("-b");
             args.push(branch);

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -47,11 +47,11 @@ pub fn login_file_path() -> Result<PathBuf, std::io::Error> {
     let dir = home::home_dir().unwrap_or(env::current_dir()?);
     let security_directory = dir.join(".soldeer");
     if !security_directory.exists() {
-        debug!(dir:? = dir; ".soldeer folder does not exist, creating it");
+        debug!(dir:?; ".soldeer folder does not exist, creating it");
         fs::create_dir(&security_directory)?;
     }
     let login_file = security_directory.join(".soldeer_login");
-    debug!(login_file:? = login_file; "path to login file");
+    debug!(login_file:?; "path to login file");
     Ok(login_file)
 }
 
@@ -132,7 +132,7 @@ pub fn hash_folder(folder_path: impl AsRef<Path>) -> Result<IntegrityChecksum, s
                     let hash = hash_content(&mut reader);
                     hasher.update(hash);
                 } else {
-                    warn!(path:? = path; "could not read file while hashing folder");
+                    warn!(path:?; "could not read file while hashing folder");
                 }
             }
             // record the hash for that file/folder in the list


### PR DESCRIPTION
When dependencies are installed from the registry or any zip URL, they often do not constitute a valid git repository (missing `.git` folder) which means that installing git submodules inside those requires special care.

The repositories need to be repaired, that is:
- `git init`
- `git submodule add` for each submodule in the `.gitmodules` file

This PR adds this logic and also makes sure that potential soldeer dependencies of subdependencies are installed recursively.

An unfortunate consequence of the missing metadata is that re-adding the submodules will clone them with the latest commit on the specified branch. So if a dependency was referencing an old commit when the zip was created, and we install it later, we might install a different version of the sub-dependency. Users who wish to use a dependency which relies on git submodules (the files are not present in the zip archive) should specify those as a `git` URL so that they are cloned with git instead of downloaded from a lossy zip file.
