### PR TITLE
chore: update bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
     id: what-happened
     attributes:
       label: What Happened?
-      description: Describe the issue you are experiencing.
+      description: Describe the issue you are experiencing. You can run `soldeer` commands with the `-vvv` flag to see debug logs.
       placeholder: A clear and concise description of what the bug is.
     validations:
       required: true


### PR DESCRIPTION
Adds a hint to use the `-vvv` flag for verbose logging.