### PR TITLE
refactor: `Path`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ uninlined-format-args = "warn"
 use-self = "warn"
 redundant-clone = "warn"
 unwrap_used = "warn"
-rustdoc = "warn"
 
 [workspace.lints.rust]
 rust-2018-idioms = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.80"
+msrv = "1.83"
 allow-unwrap-in-tests = true

--- a/crates/commands/src/commands/init.rs
+++ b/crates/commands/src/commands/init.rs
@@ -55,7 +55,7 @@ pub(crate) async fn init_command(paths: &Paths, cmd: Init) -> Result<()> {
     add_to_config(&dependency, &paths.config)?;
     let foundry_config = paths.root.join("foundry.toml");
     if foundry_config.exists() {
-        update_config_libs(foundry_config)?;
+        update_config_libs(&foundry_config)?;
     }
     success!("Dependency added to config");
     add_to_lockfile(lock, &paths.lock)?;

--- a/crates/commands/src/commands/push.rs
+++ b/crates/commands/src/commands/push.rs
@@ -79,7 +79,8 @@ pub(crate) async fn push_command(cmd: Push) -> Result<()> {
     validate_version(dependency_version)?;
 
     if let Some(zip_path) =
-        push_version(dependency_name, dependency_version, path, &files_to_copy, cmd.dry_run).await?
+        push_version(dependency_name, dependency_version, &path, &files_to_copy, cmd.dry_run)
+            .await?
     {
         info!(format!("Zip file created at {}", zip_path.to_string_lossy()));
     } else {

--- a/crates/commands/src/utils.rs
+++ b/crates/commands/src/utils.rs
@@ -140,7 +140,7 @@ pub fn get_config_location(
 ) -> Result<soldeer_core::config::ConfigLocation> {
     Ok(match arg {
         Some(loc) => loc.into(),
-        None => match detect_config_location(Paths::get_root_path()) {
+        None => match detect_config_location(&Paths::get_root_path()) {
             Some(loc) => loc,
             None => prompt_config_location()?.into(),
         },

--- a/crates/commands/tests/tests-init.rs
+++ b/crates/commands/tests/tests-init.rs
@@ -30,9 +30,9 @@ async fn test_init_clean() {
     assert!(!dir.join("lib").exists());
     assert!(!dir.join(".gitmodules").exists());
     assert!(dir.join("dependencies").exists());
-    let (deps, _) = read_config_deps(dir.join("soldeer.toml")).unwrap();
+    let (deps, _) = read_config_deps(&dir.join("soldeer.toml")).unwrap();
     assert_eq!(deps.first().unwrap().name(), "forge-std");
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(lock.entries.first().unwrap().name(), "forge-std");
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
     assert!(remappings.contains("forge-std"));
@@ -62,9 +62,9 @@ async fn test_init_no_clean() {
     assert!(dir.join("lib").exists());
     assert!(dir.join(".gitmodules").exists());
     assert!(dir.join("dependencies").exists());
-    let (deps, _) = read_config_deps(dir.join("soldeer.toml")).unwrap();
+    let (deps, _) = read_config_deps(&dir.join("soldeer.toml")).unwrap();
     assert_eq!(deps.first().unwrap().name(), "forge-std");
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(lock.entries.first().unwrap().name(), "forge-std");
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
     assert!(remappings.contains("forge-std"));

--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -18,11 +18,11 @@ fn check_install(dir: &Path, name: &str, version_req: &str) {
     if !config_path.exists() {
         config_path = dir.join("foundry.toml");
     }
-    let (deps, _) = read_config_deps(config_path).unwrap();
+    let (deps, _) = read_config_deps(&config_path).unwrap();
     assert_eq!(deps.first().unwrap().name(), name);
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
     assert!(remappings.contains(name));
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(lock.entries.first().unwrap().name(), name);
     let version = lock.entries.first().unwrap().version();
     assert!(version.starts_with(version_req));
@@ -87,7 +87,7 @@ async fn test_install_custom_http() {
     .await;
     assert!(res.is_ok(), "{res:?}");
     check_install(&dir, "mylib", "1.0.0");
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(
         lock.entries.first().unwrap().as_http().unwrap().url,
         "https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip"
@@ -111,7 +111,7 @@ async fn test_install_git_main() {
     .await;
     assert!(res.is_ok(), "{res:?}");
     check_install(&dir, "mylib", "0.1.0");
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(
         lock.entries.first().unwrap().as_git().unwrap().rev,
         "d5d72fa135d28b2e8307650b3ea79115183f2406"
@@ -136,7 +136,7 @@ async fn test_install_git_commit() {
     .await;
     assert!(res.is_ok(), "{res:?}");
     check_install(&dir, "mylib", "0.1.0");
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(
         lock.entries.first().unwrap().as_git().unwrap().rev,
         "78c2f6a1a54db26bab6c3f501854a1564eb3707f"
@@ -161,7 +161,7 @@ async fn test_install_git_tag() {
     .await;
     assert!(res.is_ok(), "{res:?}");
     check_install(&dir, "mylib", "0.1.0");
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(
         lock.entries.first().unwrap().as_git().unwrap().rev,
         "78c2f6a1a54db26bab6c3f501854a1564eb3707f"
@@ -186,7 +186,7 @@ async fn test_install_git_branch() {
     .await;
     assert!(res.is_ok(), "{res:?}");
     check_install(&dir, "mylib", "dev");
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(
         lock.entries.first().unwrap().as_git().unwrap().rev,
         "8d903e557e8f1b6e62bde768aa456d4ddfca72c4"

--- a/crates/commands/tests/tests-uninstall.rs
+++ b/crates/commands/tests/tests-uninstall.rs
@@ -46,11 +46,11 @@ async fn test_uninstall_one() {
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
-    let (deps, _) = read_config_deps(dir.join("soldeer.toml")).unwrap();
+    let (deps, _) = read_config_deps(&dir.join("soldeer.toml")).unwrap();
     assert!(!deps.iter().any(|d| d.name() == "solady"));
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
     assert!(!remappings.contains("solady"));
-    let lock = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lock = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert!(!lock.entries.iter().any(|d| d.name() == "solady"));
     assert!(!dir.join("dependencies").join("solady-0.0.238").exists());
 }
@@ -73,7 +73,7 @@ async fn test_uninstall_all() {
     .await;
     assert!(res.is_ok(), "{res:?}");
 
-    let (deps, _) = read_config_deps(dir.join("soldeer.toml")).unwrap();
+    let (deps, _) = read_config_deps(&dir.join("soldeer.toml")).unwrap();
     assert!(deps.is_empty());
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
     assert_eq!(remappings, "");
@@ -90,7 +90,7 @@ async fn test_uninstall_foundry_config() {
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
-    let (deps, _) = read_config_deps(dir.join("foundry.toml")).unwrap();
+    let (deps, _) = read_config_deps(&dir.join("foundry.toml")).unwrap();
     assert!(!deps.iter().any(|d| d.name() == "solady"));
     let config = fs::read_to_string(dir.join("foundry.toml")).unwrap();
     assert!(!config.contains("solady"));

--- a/crates/commands/tests/tests-update.rs
+++ b/crates/commands/tests/tests-update.rs
@@ -51,7 +51,7 @@ async fn test_update_existing() {
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
-    let lockfile = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lockfile = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     let version = lockfile.entries.first().unwrap().version();
     assert_ne!(version, "1.9.0");
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
@@ -69,7 +69,7 @@ async fn test_update_foundry_config() {
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
-    let lockfile = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lockfile = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     let version = lockfile.entries.first().unwrap().version();
     assert_ne!(version, "1.9.0");
     assert!(dir.join("dependencies").join(format!("forge-std-{version}")).exists());
@@ -89,7 +89,7 @@ forge-std = "1"
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
-    let lockfile = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lockfile = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     let version = lockfile.entries.first().unwrap().version();
     assert!(dir.join("dependencies").join(format!("forge-std-{version}")).exists());
 }
@@ -107,7 +107,7 @@ async fn test_update_custom_remappings() {
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
-    let lockfile = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lockfile = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     let version = lockfile.entries.first().unwrap().version();
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
     assert_eq!(remappings, format!("forge-std/=dependencies/forge-std-{version}/src/\n"));
@@ -144,7 +144,7 @@ rev = "78c2f6a1a54db26bab6c3f501854a1564eb3707f"
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
-    let lockfile = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lockfile = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(
         lockfile.entries.first().unwrap().as_git().unwrap().rev,
         "d5d72fa135d28b2e8307650b3ea79115183f2406"
@@ -182,7 +182,7 @@ rev = "78c2f6a1a54db26bab6c3f501854a1564eb3707f"
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
-    let lockfile = read_lockfile(dir.join("soldeer.lock")).unwrap();
+    let lockfile = read_lockfile(&dir.join("soldeer.lock")).unwrap();
     assert_eq!(
         lockfile.entries.first().unwrap().as_git().unwrap().rev,
         "8d903e557e8f1b6e62bde768aa456d4ddfca72c4"

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -625,7 +625,7 @@ async fn install_subdependencies_inner(paths: Paths) -> Result<()> {
 }
 
 /// Retrieve a map of git submodules for a path by looking at the `.gitmodules` file.
-async fn get_submodules(path: &PathBuf) -> Result<HashMap<String, Submodule>> {
+async fn get_submodules(path: &Path) -> Result<HashMap<String, Submodule>> {
     let submodules_config =
         run_git_command(&["config", "-f", ".gitmodules", "-l"], Some(path)).await?;
     let mut submodules = HashMap::<String, Submodule>::new();
@@ -651,7 +651,7 @@ async fn get_submodules(path: &PathBuf) -> Result<HashMap<String, Submodule>> {
 /// repo.
 ///
 /// The file is parsed, and each module is added again with `git submodule add`.
-async fn reinit_submodules(path: &PathBuf) -> Result<Vec<PathBuf>> {
+async fn reinit_submodules(path: &Path) -> Result<Vec<PathBuf>> {
     debug!(path:?; "running git init");
     run_git_command(&["init"], Some(path)).await?;
     let submodules = get_submodules(path).await?;


### PR DESCRIPTION
Improve `&Path` and `PathBuf` handling, see individual commits. Reduces unnecessary indirections and compilation impact from extra monomorphization of big functions.