### PR TITLE
chore: add nix flake and fix clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ uninlined-format-args = "warn"
 use-self = "warn"
 redundant-clone = "warn"
 unwrap_used = "warn"
-rustdoc = "warn"
 
 [workspace.lints.rust]
 rust-2018-idioms = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,1 @@
-msrv = "1.80"
 allow-unwrap-in-tests = true

--- a/crates/core/src/download.rs
+++ b/crates/core/src/download.rs
@@ -53,6 +53,7 @@ pub async fn unzip_file(path: impl AsRef<Path>, into: impl AsRef<Path>) -> Resul
 
     tokio::task::spawn_blocking({
         let out_dir = into.as_ref().to_path_buf();
+        #[allow(deprecated)] // until we can get rid of zip_extract
         move || zip_extract::extract(Cursor::new(zip_contents), &out_dir, true)
     })
     .await??;

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,66 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1753080170,
+        "narHash": "sha256-VyfFYce2UviccSmYZM7C4SkmWdbhnO9eeQZ9yQmjHRk=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "7c1a950d094671efefb007a8ab03859e2ce6c38e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752997324,
+        "narHash": "sha256-vtTM4oDke3SeDj+1ey6DjmzXdq8ZZSCLWSaApADDvIE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7c688a0875df5a8c28a53fb55ae45e94eae0dddb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753008875,
+        "narHash": "sha256-KYavlyBR385om3AOEF+ABCjslJF7vi/Eufo2L56Hhfg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "58e507d80728f6f32c93117668dc4510ba80bac9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -35,10 +35,10 @@
             buildInputs = with pkgs; [
               cargo-nextest
               foundry
+              nightlyToolchain
               openssl
               pkg-config
               toolchain
-              nightlyToolchain
             ];
 
             RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, fenix }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ fenix.overlays.default ];
+          };
+          toolchain = fenix.packages.${system}.stable.withComponents [
+            "rustc"
+            "cargo"
+            "rust-std"
+            "clippy-preview"
+            "rust-analyzer-preview"
+            "rust-src"
+          ];
+          nightlyToolchain = fenix.packages.${system}.latest.withComponents [
+            "rustfmt-preview"
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              cargo-nextest
+              foundry
+              openssl
+              pkg-config
+              toolchain
+              nightlyToolchain
+            ];
+
+            RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Added a flake for development since I'm always struggling with missing openSSL on nixOS. Also silenced a deprecation warning.