### PR TITLE
feat: allow install with no version specifier

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -28,12 +28,12 @@ path.
 ### From the Soldeer Registry
 
 ```bash
-[forge] soldeer install <NAME>~<VERSION>
+[forge] soldeer install <NAME>[~<VERSION>]
 ```
 
 This command searches the Soldeer registry at [https://soldeer.xyz](https://soldeer.xyz) for the specified dependency
-by name and version. If a match is found, a ZIP file containing the package source will be downloaded and unzipped into
-the `dependencies` directory.
+by name and optional version. If a match is found, a ZIP file containing the package source will be downloaded and
+unzipped into the `dependencies` directory. If the tilde and version are omitted, the latest version is used.
 
 The command also adds the dependency to the project's config file and creates the necessary
 [remappings](https://book.getfoundry.sh/projects/dependencies#remapping-dependencies) if configured to do so.

--- a/crates/commands/src/commands/install.rs
+++ b/crates/commands/src/commands/install.rs
@@ -1,4 +1,3 @@
-use super::validate_dependency;
 use crate::{
     utils::{remark, success, warning, Progress},
     ConfigLocation,
@@ -42,7 +41,7 @@ pub struct Install {
     /// The dependency name and optionally a version specifier separated by a tilde.
     ///
     /// If this argument is omitted, this command will install all dependencies.
-    #[arg(value_parser = validate_dependency, value_name = "DEPENDENCY[~VERSION]")]
+    #[arg(value_name = "DEPENDENCY[~VERSION]")]
     pub dependency: Option<String>,
 
     /// The URL to the dependency zip file.

--- a/crates/commands/src/commands/mod.rs
+++ b/crates/commands/src/commands/mod.rs
@@ -74,7 +74,7 @@ pub struct Version {}
 
 fn validate_dependency(dep: &str) -> std::result::Result<String, String> {
     if dep.split('~').count() != 2 {
-        return Err("The dependency should be in the format <DEPENDENCY>[~<VERSION>]".to_string());
+        return Err("The dependency should be in the format <DEPENDENCY>~<VERSION>".to_string());
     }
     Ok(dep.to_string())
 }

--- a/crates/commands/src/commands/mod.rs
+++ b/crates/commands/src/commands/mod.rs
@@ -73,7 +73,7 @@ pub enum Command {
 pub struct Version {}
 
 fn validate_dependency(dep: &str) -> std::result::Result<String, String> {
-    if dep.split('~').count() > 2 {
+    if dep.split('~').count() != 2 {
         return Err("The dependency should be in the format <DEPENDENCY>[~<VERSION>]".to_string());
     }
     Ok(dep.to_string())

--- a/crates/commands/src/commands/mod.rs
+++ b/crates/commands/src/commands/mod.rs
@@ -73,8 +73,8 @@ pub enum Command {
 pub struct Version {}
 
 fn validate_dependency(dep: &str) -> std::result::Result<String, String> {
-    if dep.split('~').count() != 2 {
-        return Err("The dependency should be in the format <DEPENDENCY>~<VERSION>".to_string());
+    if dep.split('~').count() > 2 {
+        return Err("The dependency should be in the format <DEPENDENCY>[~<VERSION>]".to_string());
     }
     Ok(dep.to_string())
 }

--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -58,6 +58,20 @@ async fn test_install_registry_wildcard() {
 }
 
 #[tokio::test]
+async fn test_install_registry_latest() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install::builder().dependency("solady").build().into();
+    let res = async_with_vars(
+        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(res.is_ok(), "{res:?}");
+    check_install(&dir, "solady", "");
+}
+
+#[tokio::test]
 async fn test_install_registry_specific_version() {
     let dir = testdir!();
     fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();

--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -72,6 +72,19 @@ async fn test_install_registry_latest() {
 }
 
 #[tokio::test]
+async fn test_install_custom_url_missing_version() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+    let cmd: Command = Install::builder().dependency("mylib").zip_url("https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip").build().into();
+    let res = async_with_vars(
+        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(res.is_err(), "{res:?}");
+}
+
+#[tokio::test]
 async fn test_install_registry_specific_version() {
     let dir = testdir!();
     fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -398,7 +398,7 @@ pub enum Dependency {
 }
 
 impl Dependency {
-    /// Create a new dependency from its name, using the latest version from the online registry.
+    /// Create a new dependency from its name, using the latest version from the registry.
     pub async fn from_name(name: &str) -> Result<Self> {
         get_latest_version(name).await.map_err(Into::into)
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2,6 +2,7 @@
 use crate::{
     download::{find_install_path, find_install_path_sync},
     errors::ConfigError,
+    registry::get_latest_version,
     remappings::RemappingsLocation,
 };
 use derive_more::derive::{Display, From, FromStr};
@@ -397,6 +398,11 @@ pub enum Dependency {
 }
 
 impl Dependency {
+    /// Create a new dependency from its name, using the latest version from the online registry.
+    pub async fn from_name(name: &str) -> Result<Self> {
+        get_latest_version(name).await.map_err(Into::into)
+    }
+
     /// Create a new dependency from a name and version requirement string.
     ///
     /// The string should be in the format `name~version_req`.

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -96,6 +96,9 @@ pub enum ConfigError {
     #[error("error during config operation: {0}")]
     DownloadError(#[from] DownloadError),
 
+    #[error("error during registry operation: {0}")]
+    RegistryError(#[from] RegistryError),
+
     #[error("the version requirement string for {0} cannot contain the equal symbol for git dependencies and http dependencies with a custom URL")]
     InvalidVersionReq(String),
 

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -164,7 +164,7 @@ pub async fn get_latest_version(dependency_name: &str) -> Result<Dependency> {
     debug!(dep = dependency_name, version = data.version; "latest version found");
     Ok(HttpDependency {
         name: dependency_name.to_string(),
-        version_req: data.clone().version,
+        version_req: data.version.clone(),
         url: None,
     }
     .into())


### PR DESCRIPTION
Closes https://github.com/mario-eth/soldeer/issues/103

The `install` command now accepts a package name without version specifier if no custom URL is provided (i.e. we use the soldeer.xyz registry). This defaults to using the latest version from the API's response.

A bonus fix from this is that the following version specifier is now accepted: `my_package~~1.2.3` which means version = `~1.2.3` which means only the patch number can increase.

Note: this assumes that the API returns the versions in descending order. This is mostly true but could be wrong in the case where an older version was added later (currently sorted by creation date). If all versions adhere to semver, it's trivial to sort them by semver like we do in `get_all_versions_descending`. Once the backend can ensure this, we can remove the sorting code from the CLI.