### PR TITLE
feat: add support for CLI tokens

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -198,6 +198,7 @@ In order to push a new dependency to the repository, an account must first be cr
 website.
 
 Finally, the `[forge] soldeer login` command must be used to retrieve an access token for the API.
+Alternatively, you can provide a valid CLI token via the `SOLDEER_API_TOKEN` environment variable.
 
 Example:
 

--- a/crates/commands/src/commands/login.rs
+++ b/crates/commands/src/commands/login.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use email_address_parser::{EmailAddress, ParsingOptions};
 use path_slash::PathBufExt as _;
 use soldeer_core::{
-    auth::{execute_login, Credentials},
+    auth::{check_token, execute_login, save_token, Credentials},
     errors::AuthError,
     Result,
 };
@@ -19,16 +19,31 @@ use std::path::PathBuf;
 #[non_exhaustive]
 pub struct Login {
     /// Specify the email without prompting.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "token")]
     pub email: Option<String>,
 
     /// Specify the password without prompting.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "token")]
     pub password: Option<String>,
+
+    /// Login with a token created via soldeer.xyz.
+    #[arg(long)]
+    pub token: Option<String>,
 }
 
 pub(crate) async fn login_command(cmd: Login) -> Result<()> {
     remark!("If you do not have an account, please visit soldeer.xyz to create one.");
+
+    if let Some(token) = cmd.token {
+        let token = token.trim();
+        let username = check_token(token).await?;
+        let token_path = save_token(token)?;
+        info!(format!(
+            "Token is valid for user {username} and was saved in: {}",
+            PathBuf::from_slash_lossy(&token_path).to_string_lossy() /* normalize separators */
+        ));
+        return Ok(());
+    }
 
     let email: String = match cmd.email {
         Some(email) => {
@@ -70,7 +85,7 @@ pub(crate) async fn login_command(cmd: Login) -> Result<()> {
     let token_path = execute_login(&Credentials { email, password }).await?;
     success!("Login successful");
     info!(format!(
-        "Login details saved in: {}",
+        "Token saved in: {}",
         PathBuf::from_slash_lossy(&token_path).to_string_lossy() /* normalize separators */
     ));
     Ok(())

--- a/crates/commands/src/commands/push.rs
+++ b/crates/commands/src/commands/push.rs
@@ -14,7 +14,10 @@ use std::{env, path::PathBuf, sync::atomic::Ordering};
 #[allow(clippy::duplicated_attributes)]
 #[builder(on(String, into), on(PathBuf, into))]
 #[clap(
-    long_about = "Push a Dependency to the Repository
+    long_about = "Push a dependency to the soldeer.xyz repository.
+
+You need to be logged in first (soldeer login) or provide the `SOLDEER_API_TOKEN` environment variable with a valid
+CLI token generated on soldeer.xyz.
 
 Examples:
 - Current directory: soldeer push mypkg~0.1.0

--- a/crates/commands/tests/tests-login.rs
+++ b/crates/commands/tests/tests-login.rs
@@ -1,41 +1,33 @@
 use std::{fs, path::PathBuf};
 
 use mockito::{Matcher, Mock, ServerGuard};
-use reqwest::StatusCode;
 use soldeer_commands::{commands::login::Login, run, Command, Verbosity};
 use temp_env::async_with_vars;
 use testdir::testdir;
 
-async fn mock_api_server(status_code: Option<StatusCode>) -> (ServerGuard, Mock) {
+async fn mock_api_server() -> (ServerGuard, Mock) {
     let mut server = mockito::Server::new_async().await;
     let body = r#"{"status":"success","token": "example_token_jwt"}"#;
-    server
+    let mock = server
         .mock("POST", "/api/v1/auth/login")
         .match_query(Matcher::Any)
         .with_header("content-type", "application/json")
         .with_body(body)
         .create_async()
         .await;
-    let mock = match status_code {
-        Some(status_code) => {
-            server
-                .mock("POST", "/api/v1/auth/login")
-                .with_header("content-type", "application/json")
-                .with_status(status_code.as_u16() as usize)
-                .with_body(r#"{"status":"success","token": "example_token_jwt"}"#)
-                .create_async()
-                .await
-        }
-        None => {
-            server
-                .mock("POST", "/api/v1/revision/upload")
-                .with_header("content-type", "application/json")
-                .with_body(r#"{"status":"success","data":{"data":{"project_id":"mock"}}}"#)
-                .create_async()
-                .await
-        }
-    };
+    (server, mock)
+}
 
+async fn mock_api_server_token() -> (ServerGuard, Mock) {
+    let mut server = mockito::Server::new_async().await;
+    let body = r#"{"status":"success","data":{"created_at": "2024-08-04T14:21:31.622589Z","email": "test@test.net","id": "b6d56bf0-00a5-474f-b732-f416bef53e92","organization": "test","role": "owner","updated_at": "2024-08-04T14:21:31.622589Z","username": "test","verified": true}}"#;
+    let mock = server
+        .mock("GET", "/api/v1/auth/validate-cli-token")
+        .match_query(Matcher::Any)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .create_async()
+        .await;
     (server, mock)
 }
 
@@ -48,7 +40,7 @@ async fn test_login_without_prompt_err_400() {
 
 #[tokio::test]
 async fn test_login_without_prompt_success() {
-    let (server, mock) = mock_api_server(None).await;
+    let (server, mock) = mock_api_server().await;
     let dir = testdir!();
     let login_file: PathBuf = dir.join("test_save_jwt");
 
@@ -65,4 +57,31 @@ async fn test_login_without_prompt_success() {
     assert!(login_file.exists());
     assert_eq!(fs::read_to_string(login_file).unwrap(), "example_token_jwt");
     mock.expect(1);
+}
+
+#[tokio::test]
+async fn test_login_token_success() {
+    let (server, mock) = mock_api_server_token().await;
+    let dir = testdir!();
+    let login_file: PathBuf = dir.join("test_save_jwt");
+    let cmd: Command = Login::builder().token("example_token_jwt").build().into();
+    let res = async_with_vars(
+        [
+            ("SOLDEER_API_URL", Some(server.url())),
+            ("SOLDEER_LOGIN_FILE", Some(login_file.to_string_lossy().to_string())),
+        ],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(res.is_ok());
+    assert!(login_file.exists());
+    assert_eq!(fs::read_to_string(login_file).unwrap(), "example_token_jwt");
+    mock.expect(1);
+}
+
+#[tokio::test]
+async fn test_login_token_failure() {
+    let cmd: Command = Login::builder().token("asdf").build().into();
+    let res = run(cmd, Verbosity::default()).await;
+    assert_eq!(res.unwrap_err().to_string(), "error during login: login error: invalid token");
 }

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -6,7 +6,7 @@ use reqwest::{
     Client, StatusCode,
 };
 use serde::{Deserialize, Serialize};
-use std::{fs, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
 pub type Result<T> = std::result::Result<T, AuthError>;
 
@@ -25,8 +25,15 @@ pub struct LoginResponse {
     pub token: String,
 }
 
-/// Get the JWT token from the login file
+/// Get the JWT token from the environment or from the login file
+///
+/// Precedence is given to the `SOLDEER_API_TOKEN` environment variable.
 pub fn get_token() -> Result<String> {
+    if let Ok(token) = env::var("SOLDEER_API_TOKEN") {
+        if !token.is_empty() {
+            return Ok(token)
+        }
+    }
     let token_path = login_file_path()?;
     let jwt =
         fs::read_to_string(&token_path).map_err(|_| AuthError::MissingToken)?.trim().to_string();

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -62,19 +62,12 @@ pub async fn check_token(token: &str) -> Result<String> {
                 username: String,
             }
             #[derive(Deserialize)]
-            struct UserData {
-                user: User,
-            }
-            #[derive(Deserialize)]
             struct UserResponse {
-                data: UserData,
+                data: User,
             }
             let res: UserResponse = response.json().await?;
-            debug!(
-                "token is valid for user {} with ID {}",
-                res.data.user.username, res.data.user.id
-            );
-            Ok(res.data.user.username)
+            debug!("token is valid for user {} with ID {}", res.data.username, res.data.id);
+            Ok(res.data.username)
         }
         StatusCode::UNAUTHORIZED => Err(AuthError::InvalidToken),
         _ => Err(AuthError::HttpError(

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -107,7 +107,7 @@ pub async fn execute_login(login: &Credentials) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use temp_env::async_with_vars;
+    use temp_env::{async_with_vars, with_var};
     use testdir::testdir;
 
     #[tokio::test]
@@ -224,5 +224,12 @@ mod tests {
         let res =
             async_with_vars([("SOLDEER_API_URL", Some(server.url()))], check_token("foobar")).await;
         assert!(res.is_err(), "{res:?}");
+    }
+
+    #[test]
+    fn test_get_token_env() {
+        let res = with_var("SOLDEER_API_TOKEN", Some("test"), get_token);
+        assert!(res.is_ok(), "{res:?}");
+        assert_eq!(res.unwrap(), "test");
     }
 }

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -48,7 +48,7 @@ pub fn save_token(token: &str) -> Result<PathBuf> {
 /// Retrieve user profile for the token to check its validity, returning the username
 pub async fn check_token(token: &str) -> Result<String> {
     let client = Client::new();
-    let url = api_url("users/me", &[]);
+    let url = api_url("auth/validate-cli-token", &[]);
     let mut headers: HeaderMap = HeaderMap::new();
     let header_value =
         HeaderValue::from_str(&format!("Bearer {token}")).map_err(|_| AuthError::InvalidToken)?;

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -44,6 +44,9 @@ pub enum AuthError {
     #[error("login error: invalid email or password")]
     InvalidCredentials,
 
+    #[error("login error: invalid token")]
+    InvalidToken,
+
     #[error("missing token, run `soldeer login`")]
     MissingToken,
 

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1753080170,
-        "narHash": "sha256-VyfFYce2UviccSmYZM7C4SkmWdbhnO9eeQZ9yQmjHRk=",
+        "lastModified": 1755585599,
+        "narHash": "sha256-tl/0cnsqB/Yt7DbaGMel2RLa7QG5elA8lkaOXli6VdY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "7c1a950d094671efefb007a8ab03859e2ce6c38e",
+        "rev": "6ed03ef4c8ec36d193c18e06b9ecddde78fb7e42",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752997324,
-        "narHash": "sha256-vtTM4oDke3SeDj+1ey6DjmzXdq8ZZSCLWSaApADDvIE=",
+        "lastModified": 1755268003,
+        "narHash": "sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj/w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c688a0875df5a8c28a53fb55ae45e94eae0dddb",
+        "rev": "32f313e49e42f715491e1ea7b306a87c16fe0388",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1753008875,
-        "narHash": "sha256-KYavlyBR385om3AOEF+ABCjslJF7vi/Eufo2L56Hhfg=",
+        "lastModified": 1755504847,
+        "narHash": "sha256-VX0B9hwhJypCGqncVVLC+SmeMVd/GAYbJZ0MiiUn2Pk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "58e507d80728f6f32c93117668dc4510ba80bac9",
+        "rev": "a905e3b21b144d77e1b304e49f3264f6f8d4db75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR adds support for CLI tokens by adding a `--token` arg in the `login` command and using the new `SOLDEER_API_TOKEN` environment variable if available in the `push` command.