### PR TITLE
feat: add support for private packages

### DIFF
--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -45,6 +45,18 @@ pub fn get_token() -> Result<String> {
     Ok(jwt)
 }
 
+/// Get a header map with the bearer token set up if it exists
+pub fn get_auth_headers() -> Result<HeaderMap> {
+    let mut headers: HeaderMap = HeaderMap::new();
+    let Ok(token) = get_token() else {
+        return Ok(headers);
+    };
+    let header_value =
+        HeaderValue::from_str(&format!("Bearer {token}")).map_err(|_| AuthError::InvalidToken)?;
+    headers.insert(AUTHORIZATION, header_value);
+    Ok(headers)
+}
+
 /// Save an access token in the login file
 pub fn save_token(token: &str) -> Result<PathBuf> {
     let token_path = login_file_path()?;

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -256,6 +256,9 @@ pub enum RegistryError {
     )]
     ProjectNotFound(String),
 
+    #[error("auth error: {0}")]
+    AuthError(#[from] AuthError),
+
     #[error("package {0} has no version")]
     NoVersion(String),
 

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -185,8 +185,8 @@ pub enum LockError {
     #[error("error generating soldeer.lock contents: {0}")]
     SerializeError(#[from] toml_edit::ser::Error),
 
-    #[error("lock entry does not match expected type")]
-    TypeMismatch,
+    #[error("lock entry does not match a valid format")]
+    InvalidLockEntry,
 
     #[error("missing `{field}` field in lock entry for {dep}")]
     MissingField { field: String, dep: String },

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -252,7 +252,7 @@ pub enum RegistryError {
     URLNotFound(String),
 
     #[error(
-        "project {0} not found, please check the dependency name (project name) or create a new project on https://soldeer.xyz"
+        "project {0} not found. Private projects require to log in before install. Please check the dependency name (project name) or create a new project on https://soldeer.xyz"
     )]
     ProjectNotFound(String),
 

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -16,6 +16,15 @@ use std::{
 
 pub type Result<T> = std::result::Result<T, LockError>;
 
+/// A trait implemented by lockfile entries to provide the install path
+pub trait Integrity {
+    /// Returns the install path of the dependency.
+    fn install_path(&self, deps: impl AsRef<Path>) -> PathBuf;
+
+    /// Returns the integrity checksum if relevant.
+    fn integrity(&self) -> Option<&String>;
+}
+
 /// A lock entry for a git dependency.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, bon::Builder)]
 #[builder(on(String, into))]
@@ -35,13 +44,18 @@ pub struct GitLockEntry {
     pub rev: String,
 }
 
-impl GitLockEntry {
+impl Integrity for GitLockEntry {
     /// Returns the install path of the dependency.
     ///
     /// The directory does not need to exist. Since the lock entry contains the version,
     /// the install path can be calculated without needing to check the actual directory.
-    pub fn install_path(&self, deps: impl AsRef<Path>) -> PathBuf {
+    fn install_path(&self, deps: impl AsRef<Path>) -> PathBuf {
         format_install_path(&self.name, &self.version, deps)
+    }
+
+    /// There is no integrity checksum for git lock entries
+    fn integrity(&self) -> Option<&String> {
+        None
     }
 }
 
@@ -71,13 +85,59 @@ pub struct HttpLockEntry {
     pub integrity: String,
 }
 
-impl HttpLockEntry {
+impl Integrity for HttpLockEntry {
     /// Returns the install path of the dependency.
     ///
     /// The directory does not need to exist. Since the lock entry contains the version,
     /// the install path can be calculated without needing to check the actual directory.
-    pub fn install_path(&self, deps: impl AsRef<Path>) -> PathBuf {
+    fn install_path(&self, deps: impl AsRef<Path>) -> PathBuf {
         format_install_path(&self.name, &self.version, deps)
+    }
+
+    /// Returns the integrity checksum
+    fn integrity(&self) -> Option<&String> {
+        Some(&self.integrity)
+    }
+}
+
+/// A lock entry for a private dependency.
+///
+/// The link is not stored in the lockfile as it must be fetched from the registry with a valid
+/// token before each download.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, bon::Builder)]
+#[builder(on(String, into))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct PrivateLockEntry {
+    /// The name of the dependency.
+    pub name: String,
+
+    /// The resolved version of the dependency (not necessarily matches the version requirement of
+    /// the dependency).
+    ///
+    /// If the version req is a semver range, then this will be the exact version that was
+    /// resolved.
+    pub version: String,
+
+    /// The checksum of the downloaded zip file.
+    pub checksum: String,
+
+    /// The integrity hash of the downloaded zip file after extraction.
+    pub integrity: String,
+}
+
+impl Integrity for PrivateLockEntry {
+    /// Returns the install path of the dependency.
+    ///
+    /// The directory does not need to exist. Since the lock entry contains the version,
+    /// the install path can be calculated without needing to check the actual directory.
+    fn install_path(&self, deps: impl AsRef<Path>) -> PathBuf {
+        format_install_path(&self.name, &self.version, deps)
+    }
+
+    /// Returns the integrity checksum
+    fn integrity(&self) -> Option<&String> {
+        Some(&self.integrity)
     }
 }
 
@@ -109,6 +169,9 @@ pub enum LockEntry {
 
     /// A lock entry for a git dependency.
     Git(GitLockEntry),
+
+    /// A lock entry for a git dependency.
+    Private(PrivateLockEntry),
 }
 
 /// A TOML representation of a lock entry, which merges all fields from the two variants of
@@ -150,6 +213,15 @@ impl From<LockEntry> for TomlLockEntry {
                 checksum: None,
                 integrity: None,
             },
+            LockEntry::Private(lock) => Self {
+                name: lock.name,
+                version: lock.version,
+                git: None,
+                url: None,
+                rev: None,
+                checksum: Some(lock.checksum),
+                integrity: Some(lock.integrity),
+            },
         }
     }
 }
@@ -159,8 +231,31 @@ impl TryFrom<TomlLockEntry> for LockEntry {
 
     /// Convert a [`TomlLockEntry`] into a [`LockEntry`] if possible.
     fn try_from(value: TomlLockEntry) -> std::result::Result<Self, Self::Error> {
-        if let Some(url) = value.url {
-            Ok(HttpLockEntry::builder()
+        match (value.url, value.git) {
+            (None, None) => Ok(PrivateLockEntry::builder()
+                .name(&value.name)
+                .version(value.version)
+                .checksum(value.checksum.ok_or(LockError::MissingField {
+                    field: "checksum".to_string(),
+                    dep: value.name.clone(),
+                })?)
+                .integrity(value.integrity.ok_or(LockError::MissingField {
+                    field: "integrity".to_string(),
+                    dep: value.name.clone(),
+                })?)
+                .build()
+                .into()),
+            (None, Some(git)) => Ok(GitLockEntry::builder()
+                .name(&value.name)
+                .version(value.version)
+                .git(git)
+                .rev(value.rev.ok_or(LockError::MissingField {
+                    field: "rev".to_string(),
+                    dep: value.name.clone(),
+                })?)
+                .build()
+                .into()),
+            (Some(url), None) => Ok(HttpLockEntry::builder()
                 .name(&value.name)
                 .version(value.version)
                 .url(url)
@@ -173,21 +268,8 @@ impl TryFrom<TomlLockEntry> for LockEntry {
                     dep: value.name.clone(),
                 })?)
                 .build()
-                .into())
-        } else {
-            Ok(GitLockEntry::builder()
-                .name(&value.name)
-                .version(value.version)
-                .git(value.git.ok_or(LockError::MissingField {
-                    field: "git".to_string(),
-                    dep: value.name.clone(),
-                })?)
-                .rev(value.rev.ok_or(LockError::MissingField {
-                    field: "rev".to_string(),
-                    dep: value.name.clone(),
-                })?)
-                .build()
-                .into())
+                .into()),
+            (Some(_), Some(_)) => Err(LockError::TypeMismatch),
         }
     }
 }
@@ -198,6 +280,7 @@ impl LockEntry {
         match self {
             Self::Git(lock) => &lock.name,
             Self::Http(lock) => &lock.name,
+            Self::Private(lock) => &lock.name,
         }
     }
 
@@ -206,6 +289,7 @@ impl LockEntry {
         match self {
             Self::Git(lock) => &lock.version,
             Self::Http(lock) => &lock.version,
+            Self::Private(lock) => &lock.version,
         }
     }
 
@@ -214,6 +298,7 @@ impl LockEntry {
         match self {
             Self::Git(lock) => lock.install_path(deps),
             Self::Http(lock) => lock.install_path(deps),
+            Self::Private(lock) => lock.install_path(deps),
         }
     }
 
@@ -225,6 +310,11 @@ impl LockEntry {
     /// Get the underlying [`GitLockEntry`] if this is a git lock entry.
     pub fn as_git(&self) -> Option<&GitLockEntry> {
         if let Self::Git(l) = self { Some(l) } else { None }
+    }
+
+    /// Get the underlying [`PrivateLockEntry`] if this is a private package lock entry.
+    pub fn as_private(&self) -> Option<&PrivateLockEntry> {
+        if let Self::Private(l) = self { Some(l) } else { None }
     }
 }
 
@@ -239,6 +329,13 @@ impl From<GitLockEntry> for LockEntry {
     /// Wrap a [`GitLockEntry`] in a [`LockEntry`].
     fn from(value: GitLockEntry) -> Self {
         Self::Git(value)
+    }
+}
+
+impl From<PrivateLockEntry> for LockEntry {
+    /// Wrap a [`PrivateLockEntry`] in a [`LockEntry`].
+    fn from(value: PrivateLockEntry) -> Self {
+        Self::Private(value)
     }
 }
 

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -153,7 +153,7 @@ pub async fn get_dependency_url_remote(dependency: &Dependency, version: &str) -
 pub async fn get_project_id(dependency_name: &str) -> Result<String> {
     debug!(name = dependency_name; "retrieving project ID");
     let url = api_url("v2", "project", &[("project_name", dependency_name)]);
-    let res = reqwest::get(url).await?;
+    let res = Client::new().get(url).headers(get_auth_headers()?).send().await?;
     let res = res.error_for_status()?;
     let project: ProjectResponse = res.json().await?;
     let Some(p) = project.data.first() else {
@@ -171,7 +171,7 @@ pub async fn get_latest_version(dependency_name: &str) -> Result<Dependency> {
         "revision",
         &[("project_name", dependency_name), ("offset", "0"), ("limit", "1")],
     );
-    let res = reqwest::get(url).await?;
+    let res = Client::new().get(url).headers(get_auth_headers()?).send().await?;
     let res = res.error_for_status()?;
     let revision: RevisionResponse = res.json().await?;
     let Some(data) = revision.data.first() else {
@@ -214,7 +214,7 @@ pub async fn get_all_versions_descending(dependency_name: &str) -> Result<Versio
         "revision",
         &[("project_name", dependency_name), ("offset", "0"), ("limit", "10000")],
     );
-    let res = reqwest::get(url).await?;
+    let res = Client::new().get(url).headers(get_auth_headers()?).send().await?;
     let res = res.error_for_status()?;
     let revision: RevisionResponse = res.json().await?;
     if revision.data.is_empty() {

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -3,12 +3,13 @@
 //! The registry client is responsible for fetching information about packages from the Soldeer
 //! registry at <https://soldeer.xyz>.
 use crate::{
+    auth::get_auth_headers,
     config::{Dependency, HttpDependency},
     errors::RegistryError,
 };
 use chrono::{DateTime, Utc};
 use log::{debug, warn};
-use reqwest::Url;
+use reqwest::{Client, Url};
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use std::env;
@@ -138,7 +139,7 @@ pub async fn get_dependency_url_remote(dependency: &Dependency, version: &str) -
         &[("project_name", dependency.name()), ("revision", version)],
     );
 
-    let res = reqwest::get(url).await?;
+    let res = Client::new().get(url).headers(get_auth_headers()?).send().await?;
     let res = res.error_for_status()?;
     let revision: RevisionResponse = res.json().await?;
     let Some(r) = revision.data.first() else {


### PR DESCRIPTION
This PR adds support for private packages from the soldeer.xyz registry. All API calls are now authenticated with the CLI token if user has provided one. Private packages are stored in the lockfile without an URL, and the URL is fetched via the API before each install.
