### PR TITLE
feat: detect project root

### DIFF
--- a/crates/commands/foundry.toml
+++ b/crates/commands/foundry.toml
@@ -1,0 +1,9 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["dependencies"]
+
+[dependencies]
+forge-std = "1.10.0"
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/crates/commands/soldeer.toml
+++ b/crates/commands/soldeer.toml
@@ -1,0 +1,2 @@
+[dependencies]
+forge-std = "1.10.0"

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -9,6 +9,7 @@ use derive_more::derive::FromStr;
 use soldeer_core::{Result, config::Paths};
 use std::{
     env,
+    path::PathBuf,
     sync::atomic::{AtomicBool, Ordering},
 };
 use utils::{get_config_location, intro, outro, outro_cancel, step};
@@ -75,7 +76,16 @@ pub async fn run(command: Command, verbosity: Verbosity<CustomLevel>) -> Result<
         Command::Init(cmd) => {
             intro!("🦌 Soldeer Init 🦌");
             step!("Initialize Foundry project to use Soldeer");
-            let root = env::current_dir()?; // for init, we always use the current dir as root
+            // for init, we always use the current dir as root, unless specified by env
+            let root = env::var("SOLDEER_PROJECT_ROOT")
+                .map(|p| {
+                    if p.is_empty() {
+                        env::current_dir().expect("could not determine current directory")
+                    } else {
+                        PathBuf::from(p)
+                    }
+                })
+                .unwrap_or(env::current_dir()?);
             let paths = Paths::with_root_and_config(
                 &root,
                 Some(get_config_location(&root, cmd.config_location)?),

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -78,14 +78,9 @@ pub async fn run(command: Command, verbosity: Verbosity<CustomLevel>) -> Result<
             step!("Initialize Foundry project to use Soldeer");
             // for init, we always use the current dir as root, unless specified by env
             let root = env::var("SOLDEER_PROJECT_ROOT")
-                .map(|p| {
-                    if p.is_empty() {
-                        env::current_dir().expect("could not determine current directory")
-                    } else {
-                        PathBuf::from(p)
-                    }
-                })
-                .unwrap_or(env::current_dir()?);
+                .ok()
+                .filter(|p| !p.is_empty())
+                .map_or(env::current_dir()?, PathBuf::from);
             let paths = Paths::with_root_and_config(
                 &root,
                 Some(get_config_location(&root, cmd.config_location)?),

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -75,7 +75,11 @@ pub async fn run(command: Command, verbosity: Verbosity<CustomLevel>) -> Result<
         Command::Init(cmd) => {
             intro!("🦌 Soldeer Init 🦌");
             step!("Initialize Foundry project to use Soldeer");
-            let paths = Paths::with_config(Some(get_config_location(cmd.config_location)?))?;
+            let root = env::current_dir()?; // for init, we always use the current dir as root
+            let paths = Paths::with_root_and_config(
+                &root,
+                Some(get_config_location(&root, cmd.config_location)?),
+            )?;
             commands::init::init_command(&paths, cmd).await.inspect_err(|_| {
                 outro_cancel!("An error occurred during initialization");
             })?;
@@ -83,7 +87,11 @@ pub async fn run(command: Command, verbosity: Verbosity<CustomLevel>) -> Result<
         }
         Command::Install(cmd) => {
             intro!("🦌 Soldeer Install 🦌");
-            let paths = Paths::with_config(Some(get_config_location(cmd.config_location)?))?;
+            let root = Paths::get_root_path();
+            let paths = Paths::with_root_and_config(
+                &root,
+                Some(get_config_location(&root, cmd.config_location)?),
+            )?;
             commands::install::install_command(&paths, cmd).await.inspect_err(|_| {
                 outro_cancel!("An error occurred during install");
             })?;
@@ -91,7 +99,11 @@ pub async fn run(command: Command, verbosity: Verbosity<CustomLevel>) -> Result<
         }
         Command::Update(cmd) => {
             intro!("🦌 Soldeer Update 🦌");
-            let paths = Paths::with_config(Some(get_config_location(cmd.config_location)?))?;
+            let root = Paths::get_root_path();
+            let paths = Paths::with_root_and_config(
+                &root,
+                Some(get_config_location(&root, cmd.config_location)?),
+            )?;
             commands::update::update_command(&paths, cmd).await.inspect_err(|_| {
                 outro_cancel!("An error occurred during the update");
             })?;
@@ -99,7 +111,9 @@ pub async fn run(command: Command, verbosity: Verbosity<CustomLevel>) -> Result<
         }
         Command::Uninstall(cmd) => {
             intro!("🦌 Soldeer Uninstall 🦌");
-            let paths = Paths::with_config(Some(get_config_location(None)?))?;
+            let root = Paths::get_root_path();
+            let paths =
+                Paths::with_root_and_config(&root, Some(get_config_location(&root, None)?))?;
             commands::uninstall::uninstall_command(&paths, &cmd).inspect_err(|_| {
                 outro_cancel!("An error occurred during uninstall");
             })?;

--- a/crates/commands/src/utils.rs
+++ b/crates/commands/src/utils.rs
@@ -1,14 +1,10 @@
 #![allow(unused_macros)]
 //! Utils for the commands crate
-use std::fmt;
+use std::{fmt, path::Path};
 
 use crate::ConfigLocation;
 use cliclack::{MultiProgress, ProgressBar, multi_progress, progress_bar, select};
-use soldeer_core::{
-    Result,
-    config::{Paths, detect_config_location},
-    install::InstallMonitoring,
-};
+use soldeer_core::{Result, config::detect_config_location, install::InstallMonitoring};
 
 /// Template for the progress bars.
 pub const PROGRESS_TEMPLATE: &str = "[{elapsed_precise}] {bar:30.magenta} ({pos}/{len}) {msg}";
@@ -136,11 +132,12 @@ impl Progress {
 
 /// Auto-detect config location or prompt the user for preference.
 pub fn get_config_location(
+    root: impl AsRef<Path>,
     arg: Option<ConfigLocation>,
 ) -> Result<soldeer_core::config::ConfigLocation> {
     Ok(match arg {
         Some(loc) => loc.into(),
-        None => match detect_config_location(Paths::get_root_path()) {
+        None => match detect_config_location(root) {
             Some(loc) => loc,
             None => prompt_config_location()?.into(),
         },

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -154,8 +154,12 @@ impl Paths {
     /// If `SOLDEER_PROJECT` root is present in the environment, this is the returned value. Else,
     /// we search for the root of the project with [`find_project_root`].
     pub fn get_root_path() -> PathBuf {
-        let res = env::var("SOLDEER_PROJECT_ROOT")
-            .map(|p| {
+        let res = env::var("SOLDEER_PROJECT_ROOT").map_or_else(
+            |_| {
+                debug!("SOLDEER_PROJECT_ROOT not defined, searching for project root");
+                find_project_root(None::<PathBuf>).expect("could not find project root")
+            },
+            |p| {
                 if p.is_empty() {
                     debug!("SOLDEER_PROJECT_ROOT exists but is empty, searching for project root");
                     find_project_root(None::<PathBuf>).expect("could not find project root")
@@ -163,11 +167,8 @@ impl Paths {
                     debug!(path = p; "root set by SOLDEER_PROJECT_ROOT");
                     PathBuf::from(p)
                 }
-            })
-            .unwrap_or_else(|_| {
-                debug!("SOLDEER_PROJECT_ROOT not defined, searching for project root");
-                find_project_root(None::<PathBuf>).expect("could not find project root")
-            });
+            },
+        );
         debug!(path:? = res; "found project root");
         res
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -100,8 +100,9 @@ impl Paths {
 
     /// Instantiate all the paths needed for Soldeer.
     ///
-    /// The root path defaults to the current directory but can be overridden with the
-    /// `SOLDEER_PROJECT_ROOT` environment variable.
+    /// The root path is automatically detected (by traversing the path) but can be overridden with
+    /// the `SOLDEER_PROJECT_ROOT` environment variable.
+    /// Alternatively, the [`Paths::with_config_and_root`] constructor can be used.
     ///
     /// If a config location is provided, it bypasses auto-detection and uses that. If `None`, then
     /// the location is auto-detected or if impossible, the `foundry.toml` file is used. If the
@@ -110,12 +111,27 @@ impl Paths {
     /// The paths are canonicalized.
     pub fn with_config(config_location: Option<ConfigLocation>) -> Result<Self> {
         let root = dunce::canonicalize(Self::get_root_path())?;
-        let config = Self::get_config_path(&root, config_location)?;
+        Self::with_root_and_config(root, config_location)
+    }
+
+    /// Instantiate all the paths needed for Soldeer.
+    ///
+    /// If a config location is provided, it bypasses auto-detection and uses that. If `None`, then
+    /// the location is auto-detected or if impossible, the `foundry.toml` file is used. If the
+    /// config file does not exist yet, it gets created with default content.
+    ///
+    /// The paths are canonicalized.
+    pub fn with_root_and_config(
+        root: impl AsRef<Path>,
+        config_location: Option<ConfigLocation>,
+    ) -> Result<Self> {
+        let root = root.as_ref();
+        let config = Self::get_config_path(root, config_location)?;
         let dependencies = root.join("dependencies");
         let lock = root.join("soldeer.lock");
         let remappings = root.join("remappings.txt");
 
-        Ok(Self { root, config, dependencies, lock, remappings })
+        Ok(Self { root: root.to_path_buf(), config, dependencies, lock, remappings })
     }
 
     /// Generate the paths object from a known root directory.
@@ -135,25 +151,25 @@ impl Paths {
 
     /// Get the root directory path.
     ///
-    /// At the moment, this is the current directory, unless overridden by the
-    /// `SOLDEER_PROJECT_ROOT` environment variable.
+    /// If `SOLDEER_PROJECT` root is present in the environment, this is the returned value. Else,
+    /// we search for the root of the project with [`find_project_root`].
     pub fn get_root_path() -> PathBuf {
-        // TODO: find the project's root directory and use that as the root instead of the current
-        // dir
-        env::var("SOLDEER_PROJECT_ROOT")
+        let res = env::var("SOLDEER_PROJECT_ROOT")
             .map(|p| {
                 if p.is_empty() {
-                    debug!("SOLDEER_PROJECT_ROOT exists but is empty, defaulting to current dir");
-                    env::current_dir().expect("could not get current dir")
+                    debug!("SOLDEER_PROJECT_ROOT exists but is empty, searching for project root");
+                    find_project_root(None::<PathBuf>).expect("could not find project root")
                 } else {
                     debug!(path = p; "root set by SOLDEER_PROJECT_ROOT");
                     PathBuf::from(p)
                 }
             })
             .unwrap_or_else(|_| {
-                debug!("SOLDEER_PROJECT_ROOT not defined, defaulting to current dir");
-                env::current_dir().expect("could not get current dir")
-            })
+                debug!("SOLDEER_PROJECT_ROOT not defined, searching for project root");
+                find_project_root(None::<PathBuf>).expect("could not find project root")
+            });
+        debug!(path:? = res; "found project root");
+        res
     }
 
     /// Get the path to the config file.
@@ -853,6 +869,41 @@ pub fn update_config_libs(foundry_config: impl AsRef<Path>) -> Result<()> {
     fs::write(&foundry_config, doc.to_string())?;
     debug!(path:? = foundry_config.as_ref(); "config file updated");
     Ok(())
+}
+
+/// Find the top-level directory of the working git tree.
+///
+/// If no `.git` folder is found in the ancestors, `None` is returned.
+fn find_git_root(relative_to: impl AsRef<Path>) -> Result<Option<PathBuf>> {
+    let root = dunce::canonicalize(relative_to)?;
+    Ok(root.ancestors().find(|p| p.join(".git").is_dir()).map(Path::to_path_buf))
+}
+
+/// Find the root of the project at the current directory or path specified by `cwd`.
+///
+/// Looks for a file named `foundry.toml` or `soldeer.toml` in the ancestors of the optional path
+/// passed as argument. If `None` is given, then the current directory is retrieved from the
+/// environment and used as the start point for the search.
+///
+/// The search is bounded by the root of the working git tree, so as to avoid false positives for
+/// nested dependencies. If no config file is found, but a `.git` folder is found, then the
+/// top-level directory of the working git tree will be returned. If the git root cannot be found,
+/// then the start point of the search is returned (current dir or given path).
+///
+/// This function is not meant to be used directly, instead use [`Paths::get_root_path`] which
+/// honors environment variables.
+fn find_project_root(cwd: Option<impl AsRef<Path>>) -> Result<PathBuf> {
+    let cwd = match cwd {
+        Some(path) => dunce::canonicalize(path)?,
+        None => env::current_dir()?,
+    };
+    let boundary = find_git_root(&cwd)?;
+    let found = cwd
+        .ancestors()
+        .take_while(|p| boundary.as_ref().map(|b| p.starts_with(b)).unwrap_or(true))
+        .find(|p| p.join("foundry.toml").is_file() || p.join("soldeer.toml").is_file())
+        .map(Path::to_path_buf);
+    Ok(found.or(boundary).unwrap_or_else(|| cwd.to_path_buf()))
 }
 
 /// Parse a dependency from a TOML value.


### PR DESCRIPTION
This PR adds auto-detection of the project root so that Soldeer commands can be run in sub-directories.

Closes #145 