### PR TITLE
fix(commands): do not init logging backend in the library crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,8 @@ dependencies = [
 name = "soldeer"
 version = "0.10.1"
 dependencies = [
+ "env_logger",
+ "log",
  "soldeer-commands",
  "tokio",
  "yansi",
@@ -2219,7 +2221,6 @@ dependencies = [
  "cliclack",
  "derive_more",
  "email-address-parser",
- "env_logger",
  "mockito",
  "path-slash",
  "rayon",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,8 @@ name = "soldeer"
 path = "src/main.rs"
 
 [dependencies]
+env_logger = { version = "0.11.9", features = ["unstable-kv"] }
+log.workspace = true
 soldeer-commands = { path = "../commands", version = "0.10.1" }
 tokio.workspace = true
 yansi = { version = "1.0.1", features = ["detect-tty", "detect-env"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,7 @@
 //! Soldeer is a package manager for Solidity projects
+use std::env;
+
+use log::Level;
 use soldeer_commands::{Args, commands::Parser as _, run};
 use yansi::{Condition, Paint as _};
 
@@ -13,6 +16,16 @@ async fn main() {
     // disable colors if unsupported
     yansi::whenever(HAVE_COLOR);
     let args = Args::parse();
+    // setup logging
+    if env::var("RUST_LOG").is_ok() {
+        env_logger::builder().init();
+    } else if let Some(level) = args.verbose.log_level() &&
+        level > Level::Error
+    {
+        // the user requested structured logging (-v[v*])
+        // init logger
+        env_logger::Builder::new().filter_level(args.verbose.log_level_filter()).init();
+    }
     if !args.verbose.is_present() {
         banner();
     }

--- a/crates/commands/Cargo.toml
+++ b/crates/commands/Cargo.toml
@@ -23,7 +23,6 @@ clap-verbosity-flag = "3.0.2"
 cliclack.workspace = true
 derive_more.workspace = true
 email-address-parser = "2.0.0"
-env_logger = { version = "0.11.6", features = ["unstable-kv"] }
 path-slash.workspace = true
 rayon.workspace = true
 soldeer-core = { path = "../core", version = "0.10.1" }


### PR DESCRIPTION
It's generally not a good practice to init a logger inside of a library crate. This PR moves this logic into the cli crate.
