### PR TITLE
fix(download): validate archive entries before extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,15 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,17 +532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -2304,7 +2284,6 @@ dependencies = [
  "toml_edit",
  "uuid",
  "zip",
- "zip-extract",
 ]
 
 [[package]]
@@ -2729,6 +2708,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -3690,27 +3675,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.6.1"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
  "flate2",
  "indexmap",
  "memchr",
+ "typed-path",
  "zopfli",
-]
-
-[[package]]
-name = "zip-extract"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa5b9958fd0b5b685af54f2c3fa21fca05fe295ebaf3e77b6d24d96c4174037"
-dependencies = [
- "log",
- "thiserror 2.0.18",
- "zip",
 ]
 
 [[package]]

--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -122,6 +122,104 @@ libs = ["lib"]
     zip_file(&root, &files, "test").unwrap()
 }
 
+fn create_zip_with_git_metadata(testdir: &Path) -> PathBuf {
+    let root = testdir.join("git_metadata_project");
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("lib/forge-std")).unwrap();
+    let mut files = Vec::new();
+    files.push(root.join("foundry.toml"));
+    fs::write(
+        files.last().unwrap(),
+        r#"[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+"#,
+    )
+    .unwrap();
+    files.push(root.join(".gitmodules"));
+    fs::write(
+        files.last().unwrap(),
+        r#"[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+"#,
+    )
+    .unwrap();
+    files.push(root.join(".git/config"));
+    fs::write(
+        files.last().unwrap(),
+        r#"[core]
+	repositoryformatversion = 0
+[submodule "lib/forge-std"]
+	url = https://github.com/foundry-rs/forge-std
+	update = !touch pwned
+"#,
+    )
+    .unwrap();
+    files.push(root.join(".git/pwn-marker"));
+    fs::write(files.last().unwrap(), "from the archive\n").unwrap();
+    // gitlink left behind by `soldeer push` on a repo with checked-out submodules
+    files.push(root.join("lib/forge-std/.git"));
+    fs::write(
+        files.last().unwrap(),
+        "gitdir: ../../.git/modules/lib/forge-std
+",
+    )
+    .unwrap();
+    zip_file(&root, &files, "test").unwrap()
+}
+
+#[tokio::test]
+async fn test_install_recursive_deps_strips_archive_git_metadata() {
+    let dir = testdir!();
+    let zip_path = create_zip_with_git_metadata(&dir);
+    let checksum = hash_file(&zip_path).unwrap();
+
+    let contents = r#"[dependencies]
+mylib = "1.0.0"
+
+[soldeer]
+recursive_deps = true
+"#;
+
+    let mut server = mockito::Server::new_async().await;
+    server.mock("GET", "/file.zip").with_body_from_file(&zip_path).create_async().await;
+    fs::write(dir.join("soldeer.toml"), contents).unwrap();
+
+    let lock = format!(
+        r#"[[dependencies]]
+name = "mylib"
+version = "1.0.0"
+url = "{}/file.zip"
+checksum = "{checksum}"
+integrity = "placeholder"
+"#,
+        server.url()
+    );
+    fs::write(dir.join(SOLDEER_LOCK), lock).unwrap();
+
+    let cmd: Command = Install::builder().build().into();
+    let res = async_with_vars(
+        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(res.is_ok(), "{res:?}");
+
+    let install_path = dir.join("dependencies/mylib-1.0.0");
+    // the archive's repository metadata never reached the install directory, so its
+    // `submodule.<name>.update` command could not run. The `.git` that is there was created by
+    // `git init` while re-adding the submodules
+    assert!(!install_path.join(".git/pwn-marker").exists());
+    let git_config = fs::read_to_string(install_path.join(".git/config")).unwrap();
+    assert!(!git_config.contains("update = !"), "{git_config}");
+    assert!(!install_path.join("pwned").exists());
+    // and the package still installs, submodule included
+    assert!(install_path.join(".gitmodules").exists());
+    assert!(install_path.join("lib/forge-std/src/Test.sol").exists());
+}
+
 #[tokio::test]
 async fn test_install_registry_any_version() {
     let dir = testdir!();

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,10 +42,7 @@ thiserror.workspace = true
 tokio.workspace = true
 toml_edit = { version = "0.25.11", features = ["serde"] }
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
-zip = { version = "4.0.0", default-features = false, features = ["deflate"] }
-zip-extract = { version = "0.4.0", default-features = false, features = [
-    "deflate",
-] }
+zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 mockito.workspace = true

--- a/crates/core/src/download.rs
+++ b/crates/core/src/download.rs
@@ -55,7 +55,7 @@ pub async fn download_file(
 ///
 /// Git repository metadata contained in the archive is never extracted. Symlink entries are written
 /// as regular files holding their target path, and any entry whose path would land outside of
-/// `into` is rejected.
+/// `into` or which names an alternate data stream is rejected.
 pub async fn unzip_file(
     path: impl AsRef<Path>,
     into: impl AsRef<Path>,
@@ -232,8 +232,9 @@ fn install_path_matches(dependency: &Dependency, path: impl AsRef<Path>) -> bool
 /// `.gitignore` and `.gitattributes` are part of the package and are extracted as usual.
 ///
 /// Symlink entries are written as regular files holding their target path. Entries whose path would
-/// land outside of `dir` are rejected, and on unix the file permissions recorded in the archive are
-/// preserved.
+/// land outside of `dir` or which name an alternate data stream are rejected, and on unix the file
+/// permissions recorded in the archive are preserved minus the setuid/setgid/sticky and
+/// group/other write bits.
 ///
 /// If `strip_root` is `true` and the archive wraps everything in a single top-level directory,
 /// that directory is stripped. This is desirable for source archives which wrap their contents in
@@ -259,7 +260,20 @@ fn extract_dependency_archive(
         if name.as_os_str().is_empty() {
             continue; // the stripped top-level directory itself
         }
-        if name.components().any(|c| c.as_os_str().eq_ignore_ascii_case(".git")) {
+        let mut is_git_metadata = false;
+        for component in name.components() {
+            let Some(component) = component.as_os_str().to_str() else {
+                continue; // a non-unicode name cannot be `.git` and cannot name a stream
+            };
+            if component.contains(':') {
+                // `foo:bar` writes to an alternate data stream of `foo` on windows
+                return Err(DownloadError::InvalidArchivePath(entry.name().to_string()));
+            }
+            // the win32 path parser strips trailing dots and spaces from each component, so we need
+            // to trim on every platform to have the same integrity checksum
+            is_git_metadata |= component.trim_end_matches(['.', ' ']).eq_ignore_ascii_case(".git");
+        }
+        if is_git_metadata {
             trace!(entry = entry.name(); "skipping git metadata found in archive");
             skipped += 1;
             continue;
@@ -281,10 +295,10 @@ fn extract_dependency_archive(
             .map_err(|e| DownloadError::IOError { path: out_path.clone(), source: e })?;
         #[cfg(unix)]
         if let Some(mode) = entry.unix_mode().filter(|_| !entry.is_symlink()) {
-            // a symlink's mode is `0o120777`, which `chmod` would turn into a world-writable file,
-            // and a directory could be made read-only before we extract its children
             use std::os::unix::fs::PermissionsExt as _;
-            fs::set_permissions(&out_path, fs::Permissions::from_mode(mode))
+            // the recorded mode is cleaned up to remove setuid/setgid/sticky, and also the `group`
+            // + `other` write bits which don't really make a lot of sense for dependencies
+            fs::set_permissions(&out_path, fs::Permissions::from_mode(mode & 0o777 & !0o022))
                 .map_err(|e| DownloadError::IOError { path: out_path.clone(), source: e })?;
         }
     }
@@ -360,6 +374,49 @@ mod tests {
         // everything else is extracted as usual
         assert!(out_dir.join(".gitmodules").exists());
         assert!(out_dir.join("src/Contract.sol").exists());
+    }
+
+    #[tokio::test]
+    async fn test_unzip_file_strips_disguised_git_metadata() {
+        // the win32 path parser strips trailing dots and spaces from each component, so these all
+        // name the `.git` directory once they reach the filesystem on windows
+        let dir = testdir!();
+        let zip_path = dir.join("disguised.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let opts = SimpleFileOptions::default();
+        for name in [".git./config", ".git /config", ".GIT/config", "lib/dep/.git.", "src/.git ."] {
+            zip.start_file(name, opts).unwrap();
+            zip.write_all(b"[core]\n").unwrap();
+        }
+        zip.start_file("src/Contract.sol", opts).unwrap();
+        zip.write_all(b"contract Contract {}\n").unwrap();
+        zip.finish().unwrap();
+
+        let out_dir = dir.join("out");
+        unzip_file(&zip_path, &out_dir, false).await.unwrap();
+        for name in [".git", ".git.", ".git ", ".GIT", "lib/dep/.git.", "src/.git ."] {
+            assert!(!out_dir.join(name).exists(), "{name} was extracted");
+        }
+        assert!(out_dir.join("src/Contract.sol").exists());
+    }
+
+    #[tokio::test]
+    async fn test_unzip_file_rejects_alternate_data_stream() {
+        let dir = testdir!();
+        let zip_path = dir.join("stream.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        zip.start_file("src/Contract.sol:hidden", SimpleFileOptions::default()).unwrap();
+        zip.write_all(b"hidden\n").unwrap();
+        zip.finish().unwrap();
+
+        let out_dir = dir.join("out");
+        let res = unzip_file(&zip_path, &out_dir, false).await;
+        assert!(
+            matches!(&res, Err(DownloadError::InvalidArchivePath(entry)) if entry == "src/Contract.sol:hidden"),
+            "{res:?}"
+        );
     }
 
     #[tokio::test]
@@ -459,6 +516,8 @@ mod tests {
         zip.write_all(b"#!/bin/sh\n").unwrap();
         zip.start_file("plain.txt", SimpleFileOptions::default().unix_permissions(0o644)).unwrap();
         zip.write_all(b"plain\n").unwrap();
+        zip.start_file("shared.txt", SimpleFileOptions::default().unix_permissions(0o777)).unwrap();
+        zip.write_all(b"shared\n").unwrap();
         zip.finish().unwrap();
 
         let out_dir = dir.join("out");
@@ -467,6 +526,8 @@ mod tests {
             |name: &str| fs::metadata(out_dir.join(name)).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode("run.sh"), 0o755);
         assert_eq!(mode("plain.txt"), 0o644);
+        // the archive cannot hand out write access to anyone but the owner
+        assert_eq!(mode("shared.txt"), 0o755);
     }
 
     #[tokio::test]

--- a/crates/core/src/download.rs
+++ b/crates/core/src/download.rs
@@ -51,6 +51,9 @@ pub async fn download_file(
 /// which wrap the contents in a root folder (e.g. GitHub-generated zips for custom URL
 /// dependencies), but must not be done for registry packages, where any top-level directory is
 /// part of the published package's layout.
+///
+/// Any git repository metadata contained in the archive is discarded after extraction, see
+/// [`remove_git_metadata`].
 pub async fn unzip_file(
     path: impl AsRef<Path>,
     into: impl AsRef<Path>,
@@ -61,22 +64,14 @@ pub async fn unzip_file(
         .await
         .map_err(|e| DownloadError::IOError { path: path.clone(), source: e })?;
 
-    let mut archive = zip::ZipArchive::new(Cursor::new(zip_contents.as_slice()))
-        .map_err(|e| DownloadError::InvalidArchiveEntry(e.to_string()))?;
-    for index in 0..archive.len() {
-        let entry = archive
-            .by_index(index)
-            .map_err(|e| DownloadError::InvalidArchiveEntry(e.to_string()))?;
-        if entry.name().split(['/', '\\']).any(|component| component.eq_ignore_ascii_case(".git")) {
-            return Err(DownloadError::InvalidArchiveEntry(entry.name().to_string()));
-        }
-    }
-    drop(archive);
-
     tokio::task::spawn_blocking({
         let out_dir = into.as_ref().to_path_buf();
-        #[allow(deprecated)] // until we can get rid of zip_extract
-        move || zip_extract::extract(Cursor::new(zip_contents), &out_dir, strip_root)
+        move || -> Result<()> {
+            #[allow(deprecated)] // until we can get rid of zip_extract
+            zip_extract::extract(Cursor::new(zip_contents), &out_dir, strip_root)?;
+            remove_git_metadata(&out_dir)
+                .map_err(|e| DownloadError::IOError { path: out_dir.clone(), source: e })
+        }
     })
     .await??;
     debug!(file:? = path, dest:? = into.as_ref(); "unzipped file");
@@ -232,6 +227,32 @@ fn install_path_matches(dependency: &Dependency, path: impl AsRef<Path>) -> bool
     path_matches(dependency, path)
 }
 
+/// Recursively remove any `.git` file or folder found inside an extracted archive.
+///
+/// Repository metadata carried by a downloaded archive is a potential vulnerability and we don't
+/// really need that information.
+///
+/// Other dotfiles such as `.gitmodules`, `.gitignore` and `.gitattributes` are part of the package
+/// and are kept (`forge` uses git submodules).
+fn remove_git_metadata(dir: &Path) -> std::io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if entry.file_name().to_string_lossy().eq_ignore_ascii_case(".git") {
+            warn!(path:?; "removing git metadata found in archive");
+            if file_type.is_dir() {
+                fs::remove_dir_all(&path)?;
+            } else {
+                fs::remove_file(&path)?;
+            }
+        } else if file_type.is_dir() {
+            remove_git_metadata(&path)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -272,7 +293,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unzip_file_rejects_git_metadata() {
+    async fn test_unzip_file_strips_git_metadata() {
         use std::io::Write as _;
         use zip::{ZipWriter, write::SimpleFileOptions};
 
@@ -280,17 +301,27 @@ mod tests {
         let zip_path = dir.join("metadata.zip");
         let file = fs::File::create(&zip_path).unwrap();
         let mut zip = ZipWriter::new(file);
-        zip.start_file(".git/config", SimpleFileOptions::default()).unwrap();
-        zip.write_all(b"[submodule]\n").unwrap();
+        let opts = SimpleFileOptions::default();
+        zip.start_file(".git/config", opts).unwrap();
+        zip.write_all(b"[submodule \"lib/dep\"]\n\tupdate = !touch pwned\n").unwrap();
+        zip.start_file("lib/dep/.git", opts).unwrap();
+        zip.write_all(b"gitdir: ../../.git/modules/dep\n").unwrap();
+        zip.start_file(".gitmodules", opts).unwrap();
+        zip.write_all(b"[submodule \"lib/dep\"]\n\tpath = lib/dep\n").unwrap();
+        zip.start_file("src/Contract.sol", opts).unwrap();
+        zip.write_all(b"contract Contract {}\n").unwrap();
         zip.finish().unwrap();
 
         let out_dir = dir.join("out");
-        let res = unzip_file(&zip_path, &out_dir, true).await;
-        assert!(
-            matches!(res, Err(DownloadError::InvalidArchiveEntry(entry)) if entry == ".git/config")
-        );
-        assert!(!out_dir.exists());
+        unzip_file(&zip_path, &out_dir, false).await.unwrap();
+        // the archive-controlled git metadata never lands on disk
+        assert!(!out_dir.join(".git").exists());
+        assert!(!out_dir.join("lib/dep/.git").exists());
+        // everything else is extracted as usual
+        assert!(out_dir.join(".gitmodules").exists());
+        assert!(out_dir.join("src/Contract.sol").exists());
     }
+
     #[tokio::test]
     async fn test_unzip_file_strip_root() {
         // archive wrapping all contents in a single root directory, like GitHub source archives

--- a/crates/core/src/download.rs
+++ b/crates/core/src/download.rs
@@ -53,8 +53,9 @@ pub async fn download_file(
 /// dependencies), but must not be done for registry packages, where any top-level directory is
 /// part of the published package's layout.
 ///
-/// Git repository metadata contained in the archive is never extracted, see
-/// [`extract_dependency_archive`].
+/// Git repository metadata contained in the archive is never extracted. Symlink entries are written
+/// as regular files holding their target path, and any entry whose path would land outside of
+/// `into` is rejected.
 pub async fn unzip_file(
     path: impl AsRef<Path>,
     into: impl AsRef<Path>,

--- a/crates/core/src/download.rs
+++ b/crates/core/src/download.rs
@@ -8,11 +8,12 @@ use log::{debug, trace, warn};
 use reqwest::{IntoUrl, Url};
 use std::{
     fs,
-    io::Cursor,
+    io::{Read, Seek},
     path::{Path, PathBuf},
     str,
 };
 use tokio::io::AsyncWriteExt as _;
+use zip::{ZipArchive, read::root_dir_common_filter};
 
 pub type Result<T> = std::result::Result<T, DownloadError>;
 
@@ -52,25 +53,21 @@ pub async fn download_file(
 /// dependencies), but must not be done for registry packages, where any top-level directory is
 /// part of the published package's layout.
 ///
-/// Any git repository metadata contained in the archive is discarded after extraction, see
-/// [`remove_git_metadata`].
+/// Git repository metadata contained in the archive is never extracted, see
+/// [`extract_dependency_archive`].
 pub async fn unzip_file(
     path: impl AsRef<Path>,
     into: impl AsRef<Path>,
     strip_root: bool,
 ) -> Result<()> {
     let path = path.as_ref().to_path_buf();
-    let zip_contents = tokio::fs::read(&path)
-        .await
-        .map_err(|e| DownloadError::IOError { path: path.clone(), source: e })?;
-
     tokio::task::spawn_blocking({
+        let path = path.clone();
         let out_dir = into.as_ref().to_path_buf();
-        move || -> Result<()> {
-            #[allow(deprecated)] // until we can get rid of zip_extract
-            zip_extract::extract(Cursor::new(zip_contents), &out_dir, strip_root)?;
-            remove_git_metadata(&out_dir)
-                .map_err(|e| DownloadError::IOError { path: out_dir.clone(), source: e })
+        move || {
+            let file = fs::File::open(&path)
+                .map_err(|e| DownloadError::IOError { path: path.clone(), source: e })?;
+            extract_dependency_archive(file, &out_dir, strip_root)
         }
     })
     .await??;
@@ -227,29 +224,73 @@ fn install_path_matches(dependency: &Dependency, path: impl AsRef<Path>) -> bool
     path_matches(dependency, path)
 }
 
-/// Recursively remove any `.git` file or folder found inside an extracted archive.
+/// Extract a downloaded dependency archive into `dir`, which is created if it does not exist.
 ///
-/// Repository metadata carried by a downloaded archive is a potential vulnerability and we don't
-/// really need that information.
+/// Git repository metadata is skipped, we never need the publisher's metadata and it's dangerous
+/// since we then run git commands in that folder. Other dotfiles such as `.gitmodules`,
+/// `.gitignore` and `.gitattributes` are part of the package and are extracted as usual.
 ///
-/// Other dotfiles such as `.gitmodules`, `.gitignore` and `.gitattributes` are part of the package
-/// and are kept (`forge` uses git submodules).
-fn remove_git_metadata(dir: &Path) -> std::io::Result<()> {
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let path = entry.path();
-        if entry.file_name().to_string_lossy().eq_ignore_ascii_case(".git") {
-            warn!(path:?; "removing git metadata found in archive");
-            if file_type.is_dir() {
-                fs::remove_dir_all(&path)?;
-            } else {
-                fs::remove_file(&path)?;
-            }
-        } else if file_type.is_dir() {
-            remove_git_metadata(&path)?;
+/// Symlink entries are written as regular files holding their target path. Entries whose path would
+/// land outside of `dir` are rejected, and on unix the file permissions recorded in the archive are
+/// preserved.
+///
+/// If `strip_root` is `true` and the archive wraps everything in a single top-level directory,
+/// that directory is stripped. This is desirable for source archives which wrap their contents in
+/// a root folder, but must not be done for registry packages.
+fn extract_dependency_archive(
+    source: impl Read + Seek,
+    dir: &Path,
+    strip_root: bool,
+) -> Result<()> {
+    let mut archive = ZipArchive::new(source)?;
+    let root = if strip_root { archive.root_dir(root_dir_common_filter)? } else { None };
+    let mut skipped = 0usize;
+    fs::create_dir_all(dir)
+        .map_err(|e| DownloadError::IOError { path: dir.to_path_buf(), source: e })?;
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index)?;
+        let Some(name) = entry.enclosed_name() else {
+            // entry cannot be placed inside the destination safely
+            return Err(DownloadError::InvalidArchivePath(entry.name().to_string()));
+        };
+        // entries filtered out of the root detection may not live under the root
+        let name = root.as_ref().map_or(name.as_path(), |r| name.strip_prefix(r).unwrap_or(&name));
+        if name.as_os_str().is_empty() {
+            continue; // the stripped top-level directory itself
+        }
+        if name.components().any(|c| c.as_os_str().eq_ignore_ascii_case(".git")) {
+            trace!(entry = entry.name(); "skipping git metadata found in archive");
+            skipped += 1;
+            continue;
+        }
+        let out_path = dir.join(name);
+        trace!(entry = entry.name(), path:? = out_path; "extracting archive entry");
+        if entry.is_dir() {
+            fs::create_dir_all(&out_path)
+                .map_err(|e| DownloadError::IOError { path: out_path.clone(), source: e })?;
+            continue;
+        }
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| DownloadError::IOError { path: parent.to_path_buf(), source: e })?;
+        }
+        let mut out_file = fs::File::create(&out_path)
+            .map_err(|e| DownloadError::IOError { path: out_path.clone(), source: e })?;
+        std::io::copy(&mut entry, &mut out_file)
+            .map_err(|e| DownloadError::IOError { path: out_path.clone(), source: e })?;
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode().filter(|_| !entry.is_symlink()) {
+            // a symlink's mode is `0o120777`, which `chmod` would turn into a world-writable file,
+            // and a directory could be made read-only before we extract its children
+            use std::os::unix::fs::PermissionsExt as _;
+            fs::set_permissions(&out_path, fs::Permissions::from_mode(mode))
+                .map_err(|e| DownloadError::IOError { path: out_path.clone(), source: e })?;
         }
     }
+    if skipped > 0 {
+        warn!(skipped, dir:?; "skipped git metadata entries found in archive");
+    }
+    debug!(dir:?; "extracted archive");
     Ok(())
 }
 
@@ -257,8 +298,9 @@ fn remove_git_metadata(dir: &Path) -> std::io::Result<()> {
 mod tests {
     use super::*;
     use crate::{config::HttpDependency, push::zip_file};
-    use std::fs;
+    use std::{fs, io::Write as _};
     use testdir::testdir;
+    use zip::{ZipWriter, write::SimpleFileOptions};
 
     #[tokio::test]
     async fn test_download_file() {
@@ -294,9 +336,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_unzip_file_strips_git_metadata() {
-        use std::io::Write as _;
-        use zip::{ZipWriter, write::SimpleFileOptions};
-
         let dir = testdir!();
         let zip_path = dir.join("metadata.zip");
         let file = fs::File::create(&zip_path).unwrap();
@@ -320,6 +359,113 @@ mod tests {
         // everything else is extracted as usual
         assert!(out_dir.join(".gitmodules").exists());
         assert!(out_dir.join("src/Contract.sol").exists());
+    }
+
+    #[tokio::test]
+    async fn test_unzip_file_rejects_path_escape() {
+        let dir = testdir!();
+        let zip_path = dir.join("escape.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        zip.start_file("../escaped.txt", SimpleFileOptions::default()).unwrap();
+        zip.write_all(b"escaped\n").unwrap();
+        zip.finish().unwrap();
+
+        let out_dir = dir.join("out");
+        let res = unzip_file(&zip_path, &out_dir, false).await;
+        assert!(
+            matches!(&res, Err(DownloadError::InvalidArchivePath(entry)) if entry == "../escaped.txt"),
+            "{res:?}"
+        );
+        assert!(!dir.join("escaped.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_unzip_file_accepts_absolute_entry_names() {
+        // some archives in the wild record entries with a leading slash, they are extracted
+        // relative to the destination like any other entry
+        let dir = testdir!();
+        let zip_path = dir.join("absolute.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        zip.start_file("/LICENSE-APACHE", SimpleFileOptions::default()).unwrap();
+        zip.write_all(b"Apache-2.0\n").unwrap();
+        zip.start_file("src/Contract.sol", SimpleFileOptions::default()).unwrap();
+        zip.write_all(b"contract Contract {}\n").unwrap();
+        zip.finish().unwrap();
+
+        let out_dir = dir.join("out");
+        unzip_file(&zip_path, &out_dir, false).await.unwrap();
+        assert_eq!(fs::read_to_string(out_dir.join("LICENSE-APACHE")).unwrap(), "Apache-2.0\n");
+        assert!(out_dir.join("src/Contract.sol").exists());
+    }
+
+    #[tokio::test]
+    async fn test_unzip_file_does_not_create_symlinks() {
+        let dir = testdir!();
+        let zip_path = dir.join("symlink.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        zip.add_symlink("link", "../../secret", SimpleFileOptions::default()).unwrap();
+        zip.start_file("file.txt", SimpleFileOptions::default()).unwrap();
+        zip.write_all(b"ok\n").unwrap();
+        zip.finish().unwrap();
+
+        let out_dir = dir.join("out");
+        unzip_file(&zip_path, &out_dir, false).await.unwrap();
+        // symlink entries are written as regular files, they never become links out of the folder
+        let link = out_dir.join("link");
+        assert!(!fs::symlink_metadata(&link).unwrap().file_type().is_symlink());
+        assert_eq!(fs::read_to_string(&link).unwrap(), "../../secret");
+        // the entry records the symlink mode `0o120777`, which must not land as a world-writable
+        // file once the format bits are dropped
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            assert_ne!(fs::metadata(&link).unwrap().permissions().mode() & 0o777, 0o777);
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_unzip_file_read_only_dir_entry() {
+        // a read-only directory recorded in the archive must not stop its children being written
+        let dir = testdir!();
+        let zip_path = dir.join("readonly.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        zip.add_directory("locked", SimpleFileOptions::default().unix_permissions(0o555)).unwrap();
+        zip.start_file("locked/file.txt", SimpleFileOptions::default()).unwrap();
+        zip.write_all(b"readable\n").unwrap();
+        zip.finish().unwrap();
+
+        let out_dir = dir.join("out");
+        unzip_file(&zip_path, &out_dir, false).await.unwrap();
+        assert_eq!(fs::read_to_string(out_dir.join("locked/file.txt")).unwrap(), "readable\n");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_unzip_file_preserves_unix_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = testdir!();
+        let zip_path = dir.join("modes.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        zip.start_file("run.sh", SimpleFileOptions::default().unix_permissions(0o755)).unwrap();
+        zip.write_all(b"#!/bin/sh\n").unwrap();
+        zip.start_file("plain.txt", SimpleFileOptions::default().unix_permissions(0o644)).unwrap();
+        zip.write_all(b"plain\n").unwrap();
+        zip.finish().unwrap();
+
+        let out_dir = dir.join("out");
+        unzip_file(&zip_path, &out_dir, false).await.unwrap();
+        let mode =
+            |name: &str| fs::metadata(out_dir.join(name)).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode("run.sh"), 0o755);
+        assert_eq!(mode("plain.txt"), 0o644);
     }
 
     #[tokio::test]

--- a/crates/core/src/download.rs
+++ b/crates/core/src/download.rs
@@ -285,7 +285,7 @@ mod tests {
         zip.finish().unwrap();
 
         let out_dir = dir.join("out");
-        let res = unzip_file(&zip_path, &out_dir).await;
+        let res = unzip_file(&zip_path, &out_dir, true).await;
         assert!(
             matches!(res, Err(DownloadError::InvalidArchiveEntry(entry)) if entry == ".git/config")
         );

--- a/crates/core/src/download.rs
+++ b/crates/core/src/download.rs
@@ -51,6 +51,18 @@ pub async fn unzip_file(path: impl AsRef<Path>, into: impl AsRef<Path>) -> Resul
         .await
         .map_err(|e| DownloadError::IOError { path: path.clone(), source: e })?;
 
+    let mut archive = zip::ZipArchive::new(Cursor::new(zip_contents.as_slice()))
+        .map_err(|e| DownloadError::InvalidArchiveEntry(e.to_string()))?;
+    for index in 0..archive.len() {
+        let entry = archive
+            .by_index(index)
+            .map_err(|e| DownloadError::InvalidArchiveEntry(e.to_string()))?;
+        if entry.name().split(['/', '\\']).any(|component| component.eq_ignore_ascii_case(".git")) {
+            return Err(DownloadError::InvalidArchiveEntry(entry.name().to_string()));
+        }
+    }
+    drop(archive);
+
     tokio::task::spawn_blocking({
         let out_dir = into.as_ref().to_path_buf();
         #[allow(deprecated)] // until we can get rid of zip_extract
@@ -225,6 +237,27 @@ mod tests {
         let file_path = out_dir.join("file.txt");
         assert!(file_path.exists());
         assert!(!zip_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_unzip_file_rejects_git_metadata() {
+        use std::io::Write as _;
+        use zip::{ZipWriter, write::SimpleFileOptions};
+
+        let dir = testdir!();
+        let zip_path = dir.join("metadata.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        zip.start_file(".git/config", SimpleFileOptions::default()).unwrap();
+        zip.write_all(b"[submodule]\n").unwrap();
+        zip.finish().unwrap();
+
+        let out_dir = dir.join("out");
+        let res = unzip_file(&zip_path, &out_dir).await;
+        assert!(
+            matches!(res, Err(DownloadError::InvalidArchiveEntry(entry)) if entry == ".git/config")
+        );
+        assert!(!out_dir.exists());
     }
 
     #[tokio::test]

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -118,7 +118,10 @@ pub enum DownloadError {
     HttpError(#[from] reqwest::Error),
 
     #[error("error extracting dependency: {0}")]
-    UnzipError(#[from] zip_extract::ZipExtractError),
+    UnzipError(#[from] zip::result::ZipError),
+
+    #[error("archive entry has an unsafe path: {0}")]
+    InvalidArchivePath(String),
 
     #[error("error during git command {args:?}: {message}")]
     GitError { message: String, args: Vec<String> },

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -120,6 +120,9 @@ pub enum DownloadError {
     #[error("error extracting dependency: {0}")]
     UnzipError(#[from] zip_extract::ZipExtractError),
 
+    #[error("downloaded archive contains a forbidden entry: {0}")]
+    InvalidArchiveEntry(String),
+
     #[error("error during git command {args:?}: {message}")]
     GitError { message: String, args: Vec<String> },
 

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -120,9 +120,6 @@ pub enum DownloadError {
     #[error("error extracting dependency: {0}")]
     UnzipError(#[from] zip_extract::ZipExtractError),
 
-    #[error("downloaded archive contains a forbidden entry: {0}")]
-    InvalidArchiveEntry(String),
-
     #[error("error during git command {args:?}: {message}")]
     GitError { message: String, args: Vec<String> },
 

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -674,6 +674,10 @@ async fn install_dependency_inner(
 /// This function checks for a `.gitmodules` file in the dependency directory and clones the
 /// submodules if it exists. If a valid Soldeer config is found at the project root (optionally a
 /// sub-dir of the dependency folder), the soldeer dependencies are installed.
+///
+/// Archives get their repository metadata stripped during extraction. Any `.git`
+/// found here was created by us, either by [`clone_repo`] for a git dependency
+/// or by [`reinit_submodules`].
 fn install_subdependencies(
     path: impl AsRef<Path>,
     project_root: Option<&PathBuf>,
@@ -684,7 +688,7 @@ fn install_subdependencies(
         if fs::metadata(&gitmodules_path).await.is_ok() {
             debug!(path:?; "found .gitmodules, installing subdependencies with git");
             if fs::metadata(path.join(".git")).await.is_ok() {
-                debug!(path:?; "subdependency contains .git directory, cloning submodules");
+                debug!(path:?; "subdependency is a git repo we created, cloning submodules");
                 run_git_command(&["submodule", "update", "--init"], Some(&path)).await?;
                 // we need to recurse into each of the submodules to ensure any soldeer sub-deps
                 // of those are also installed


### PR DESCRIPTION
This PR moves away from the deprecated `zip-extract` wrapper library and uses `zip` directly, also ensuring we don't extract potentially harmful `.git` directories and symlinks.