### PR TITLE
fix: verify that lockfile entries match their config items

### DIFF
--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -5,7 +5,7 @@ use soldeer_core::{
     SoldeerError,
     config::{ConfigLocation, read_config_deps},
     download::download_file,
-    errors::InstallError,
+    errors::{InstallError, LockError},
     lock::{SOLDEER_LOCK, read_lockfile},
     push::zip_file,
     utils::hash_file,
@@ -32,6 +32,25 @@ fn check_install(dir: &Path, name: &str, version_req: &str) {
     let version = lock.entries.first().unwrap().version();
     assert!(version.starts_with(version_req));
     assert!(dir.join("dependencies").join(format!("{name}-{version}")).exists());
+}
+
+/// Mock the registry endpoint which resolves a dependency version into a download URL.
+///
+/// Registry dependencies don't record their source in the config, so the download URL is resolved
+/// from the registry at install time instead of being taken from the lockfile. Tests which serve a
+/// dependency from a mock server therefore need to serve that endpoint too.
+async fn mock_revision(server: &mut mockito::ServerGuard, name: &str, version: &str) {
+    let data = format!(
+        r#"{{"data":[{{"created_at":"2025-09-28T12:36:09.526660Z","deleted":false,"id":"0440c261-8cdf-4738-9139-c4dc7b0c7f3e","internal_name":"{name}.zip","private":false,"project_id":"14f419e7-2d64-49e4-86b9-b44b36627786","url":"{}/file.zip","version":"{version}"}}],"status":"success"}}"#,
+        server.url()
+    );
+    server
+        .mock("GET", "/api/v1/revision-cli")
+        .match_query(Matcher::Any)
+        .with_header("content-type", "application/json")
+        .with_body(data)
+        .create_async()
+        .await;
 }
 
 fn create_zip_monorepo(testdir: &Path) -> PathBuf {
@@ -350,17 +369,36 @@ async fn test_install_missing_with_lock() {
 mylib = "1.1"
 "#;
     fs::write(dir.join("soldeer.toml"), contents).unwrap();
-    let lock = r#"[[dependencies]]
+
+    // get zip file locally for mock
+    let zip_file = download_file(
+        "https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip",
+        &dir,
+        "tmp",
+    )
+    .await
+    .unwrap();
+    let mut server = mockito::Server::new_async().await;
+    server.mock("GET", "/file.zip").with_body_from_file(zip_file).create_async().await;
+    mock_revision(&mut server, "mylib", "1.1.0").await;
+
+    let lock = format!(
+        r#"[[dependencies]]
 name = "mylib"
 version = "1.1.0"
-url = "https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip"
+url = "{}/file.zip"
 checksum = "94a73dbe106f48179ea39b00d42e5d4dd96fdc6252caa3a89ce7efdaec0b9468"
 integrity = "bcc66b553ea004dc1ccf39e9d3cda6487edec8e58446e6f04a1e7c4b2e8535f1"
-"#;
+"#,
+        server.url()
+    );
     fs::write(dir.join(SOLDEER_LOCK), lock).unwrap();
     let cmd: Command = Install::builder().build().into();
     let res = async_with_vars(
-        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        [
+            ("SOLDEER_API_URL", Some(server.url().as_str())),
+            ("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref())),
+        ],
         run(cmd, Verbosity::default()),
     )
     .await;
@@ -389,6 +427,7 @@ mylib = "1.1"
     let mut server = mockito::Server::new_async().await;
     let mock = server.mock("GET", "/file.zip").with_body_from_file(zip_file).create_async().await;
     let mock = mock.expect(1); // download link should be called exactly once
+    mock_revision(&mut server, "mylib", "1.1.0").await;
 
     let lock = format!(
         r#"[[dependencies]]
@@ -403,7 +442,10 @@ integrity = "bcc66b553ea004dc1ccf39e9d3cda6487edec8e58446e6f04a1e7c4b2e8535f1"
     fs::write(dir.join(SOLDEER_LOCK), lock).unwrap();
     let cmd: Command = Install::builder().build().into();
     let res = async_with_vars(
-        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        [
+            ("SOLDEER_API_URL", Some(server.url().as_str())),
+            ("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref())),
+        ],
         run(cmd.clone(), Verbosity::default()),
     )
     .await;
@@ -412,12 +454,97 @@ integrity = "bcc66b553ea004dc1ccf39e9d3cda6487edec8e58446e6f04a1e7c4b2e8535f1"
 
     // second install
     let res = async_with_vars(
-        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        [
+            ("SOLDEER_API_URL", Some(server.url().as_str())),
+            ("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref())),
+        ],
         run(cmd, Verbosity::default()),
     )
     .await;
     assert!(res.is_ok(), "{res:?}");
     mock.assert(); // download link was not called a second time
+}
+
+#[tokio::test]
+async fn test_install_rejects_stale_lock() {
+    let dir = testdir!();
+    // the config asks for 2.0.0 but the lockfile still records the previous 1.0.0 install
+    let contents = r#"[dependencies]
+mylib = { version = "2.0.0", url = "https://example.com/mylib.zip" }
+"#;
+    fs::write(dir.join("soldeer.toml"), contents).unwrap();
+    let lock = r#"[[dependencies]]
+name = "mylib"
+version = "1.0.0"
+url = "https://example.com/mylib.zip"
+checksum = "94a73dbe106f48179ea39b00d42e5d4dd96fdc6252caa3a89ce7efdaec0b9468"
+integrity = "bcc66b553ea004dc1ccf39e9d3cda6487edec8e58446e6f04a1e7c4b2e8535f1"
+"#;
+    fs::write(dir.join(SOLDEER_LOCK), lock).unwrap();
+
+    let cmd: Command = Install::builder().build().into();
+    let res = async_with_vars(
+        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(
+        matches!(
+            res.unwrap_err(),
+            SoldeerError::InstallError(InstallError::LockError(LockError::Mismatch { .. }))
+        ),
+        "install should refuse a lockfile entry which disagrees with the config"
+    );
+}
+
+#[tokio::test]
+async fn test_install_rejects_lockfile_url_for_registry_dep() {
+    let dir = testdir!();
+    let contents = r#"[dependencies]
+mylib = "1.1"
+"#;
+    fs::write(dir.join("soldeer.toml"), contents).unwrap();
+
+    // get zip file locally for mock
+    let zip_file = download_file(
+        "https://github.com/mario-eth/soldeer/archive/8585a7ec85a29889cec8d08f4770e15ec4795943.zip",
+        &dir,
+        "tmp",
+    )
+    .await
+    .unwrap();
+
+    let mut server = mockito::Server::new_async().await;
+    server.mock("GET", "/file.zip").with_body_from_file(zip_file).create_async().await;
+    mock_revision(&mut server, "mylib", "1.1.0").await;
+    // the config declares no URL, so the one in the lockfile must never be contacted
+    let planted =
+        server.mock("GET", "/planted.zip").with_body("planted").expect(0).create_async().await;
+
+    let lock = format!(
+        r#"[[dependencies]]
+name = "mylib"
+version = "1.1.0"
+url = "{}/planted.zip"
+checksum = "94a73dbe106f48179ea39b00d42e5d4dd96fdc6252caa3a89ce7efdaec0b9468"
+integrity = "bcc66b553ea004dc1ccf39e9d3cda6487edec8e58446e6f04a1e7c4b2e8535f1"
+"#,
+        server.url()
+    );
+    fs::write(dir.join(SOLDEER_LOCK), lock).unwrap();
+
+    let cmd: Command = Install::builder().build().into();
+    let res = async_with_vars(
+        [
+            ("SOLDEER_API_URL", Some(server.url().as_str())),
+            ("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref())),
+        ],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(res.is_ok(), "{res:?}");
+    planted.assert();
+    check_install(&dir, "mylib", "1.1");
 }
 
 #[tokio::test]
@@ -611,16 +738,20 @@ async fn test_install_recursive_project_root() {
     let zip_path = create_zip_monorepo(&dir);
     let checksum = hash_file(&zip_path).unwrap();
 
-    let contents = r#"[dependencies]
-mylib = { version = "1.0.0", project_root = "contracts" }
-
-[soldeer]
-recursive_deps = true
-"#;
-
     // serve the dependency which uses foundry in a `contracts` subfolder
     let mut server = mockito::Server::new_async().await;
     server.mock("GET", "/file.zip").with_body_from_file(zip_path).create_async().await;
+    // the URL is declared in the config, so the registry is only contacted for the nested
+    // `forge-std` dependency
+    let contents = format!(
+        r#"[dependencies]
+mylib = {{ version = "1.0.0", url = "{}/file.zip", project_root = "contracts" }}
+
+[soldeer]
+recursive_deps = true
+"#,
+        server.url()
+    );
     fs::write(dir.join("soldeer.toml"), contents).unwrap();
     let lock = format!(
         r#"[[dependencies]]
@@ -652,17 +783,19 @@ async fn test_install_recursive_project_root_invalid_path() {
     let zip_path = create_zip_monorepo(&dir);
     let checksum = hash_file(&zip_path).unwrap();
 
-    // directory traversal is forbidden
-    let contents = r#"[dependencies]
-mylib = { version = "1.0.0", project_root = "../../../contracts" }
-
-[soldeer]
-recursive_deps = true
-"#;
-
     // serve the dependency which uses foundry in a `contracts` subfolder
     let mut server = mockito::Server::new_async().await;
     server.mock("GET", "/file.zip").with_body_from_file(zip_path).create_async().await;
+    // directory traversal is forbidden
+    let contents = format!(
+        r#"[dependencies]
+mylib = {{ version = "1.0.0", url = "{}/file.zip", project_root = "../../../contracts" }}
+
+[soldeer]
+recursive_deps = true
+"#,
+        server.url()
+    );
     fs::write(dir.join("soldeer.toml"), contents).unwrap();
     let lock = format!(
         r#"[[dependencies]]
@@ -925,6 +1058,7 @@ recursive_deps = true
     // Serve the dependency via mock server
     let mut server = mockito::Server::new_async().await;
     server.mock("GET", "/file.zip").with_body_from_file(&zip_path).create_async().await;
+    mock_revision(&mut server, "mylib", "1.0.0").await;
     fs::write(dir.join("soldeer.toml"), contents).unwrap();
 
     let lock = format!(
@@ -941,7 +1075,10 @@ integrity = "placeholder"
 
     let cmd: Command = Install::builder().build().into();
     let res = async_with_vars(
-        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        [
+            ("SOLDEER_API_URL", Some(server.url().as_str())),
+            ("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref())),
+        ],
         run(cmd.clone(), Verbosity::default()),
     )
     .await;
@@ -978,6 +1115,7 @@ recursive_deps = true
     // Serve the dependency via mock server
     let mut server = mockito::Server::new_async().await;
     server.mock("GET", "/file.zip").with_body_from_file(&zip_path).create_async().await;
+    mock_revision(&mut server, "mylib", "1.0.0").await;
     fs::write(dir.join("soldeer.toml"), contents).unwrap();
 
     let lock = format!(
@@ -994,7 +1132,10 @@ integrity = "placeholder"
 
     let cmd: Command = Install::builder().build().into();
     let res = async_with_vars(
-        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        [
+            ("SOLDEER_API_URL", Some(server.url().as_str())),
+            ("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref())),
+        ],
         run(cmd.clone(), Verbosity::default()),
     )
     .await;

--- a/crates/commands/tests/tests-update.rs
+++ b/crates/commands/tests/tests-update.rs
@@ -4,7 +4,9 @@ use soldeer_commands::{
     run,
 };
 use soldeer_core::{
+    SoldeerError,
     config::ConfigLocation,
+    errors::{InstallError, LockError},
     lock::{SOLDEER_LOCK, read_lockfile},
 };
 use std::{fs, path::PathBuf};
@@ -60,6 +62,50 @@ async fn test_update_existing() {
     assert_ne!(version, "1.9.0");
     let remappings = fs::read_to_string(dir.join("remappings.txt")).unwrap();
     assert_eq!(remappings, format!("forge-std-1/=dependencies/forge-std-{version}/\n"));
+    assert!(dir.join("dependencies").join(format!("forge-std-{version}")).exists());
+}
+
+#[tokio::test]
+#[allow(clippy::unwrap_used)]
+async fn test_update_after_config_version_bump() {
+    let dir = testdir!();
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\nforge-std = \"1.9.0\"\n").unwrap();
+    let cmd: Command = Install::default().into();
+    let res = async_with_vars(
+        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(res.is_ok(), "{res:?}");
+
+    // require a version which the lockfile entry cannot satisfy
+    fs::write(dir.join("soldeer.toml"), "[dependencies]\nforge-std = \"^1.10.0\"\n").unwrap();
+
+    let cmd: Command = Install::default().into();
+    let res = async_with_vars(
+        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(
+        matches!(
+            res.unwrap_err(),
+            SoldeerError::InstallError(InstallError::LockError(LockError::Mismatch { .. }))
+        ),
+        "install should not silently keep the outdated install"
+    );
+
+    // updating re-resolves the dependency from the config
+    let cmd: Command = Update::default().into();
+    let res = async_with_vars(
+        [("SOLDEER_PROJECT_ROOT", Some(dir.to_string_lossy().as_ref()))],
+        run(cmd, Verbosity::default()),
+    )
+    .await;
+    assert!(res.is_ok(), "{res:?}");
+    let lockfile = read_lockfile(dir.join(SOLDEER_LOCK)).unwrap();
+    let version = lockfile.entries.first().unwrap().version();
+    assert_ne!(version, "1.9.0");
     assert!(dir.join("dependencies").join(format!("forge-std-{version}")).exists());
 }
 

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -197,6 +197,9 @@ pub enum LockError {
     #[error("lock entry does not match a valid format")]
     InvalidLockEntry,
 
+    #[error("lockfile entry for {dep} does not match the config: {source} (run `soldeer update`)")]
+    Mismatch { dep: String, source: LockMismatch },
+
     #[error("missing `{field}` field in lock entry for {dep}")]
     MissingField { field: String, dep: String },
 
@@ -208,6 +211,28 @@ pub enum LockError {
 
     #[error("error parsing soldeer.lock TOML contents: {0}")]
     TomlDeserializeError(#[from] toml_edit::de::Error),
+}
+
+/// The reason why a lockfile entry does not correspond to the dependency declared in the config.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum LockMismatch {
+    #[error(
+        "locked entry is a {locked} dependency but the config declares a {required} dependency"
+    )]
+    Type { locked: String, required: String },
+
+    #[error("locked version {locked} does not match the requirement {required}")]
+    Version { locked: String, required: String },
+
+    #[error("locked URL {locked} does not match the configured URL {required}")]
+    Url { locked: String, required: String },
+
+    #[error("locked git remote {locked} does not match the configured remote {required}")]
+    Git { locked: String, required: String },
+
+    #[error("locked commit {locked} does not match the configured rev {required}")]
+    Rev { locked: String, required: String },
 }
 
 #[derive(Error, Debug)]

--- a/crates/core/src/install.rs
+++ b/crates/core/src/install.rs
@@ -4,14 +4,15 @@
 //! lockfile. Dependencies can be installed in parallel.
 use crate::{
     config::{
-        Dependency, GitIdentifier, HttpDependency, Paths, detect_config_location, read_config_deps,
+        Dependency, GitIdentifier, Paths, detect_config_location, read_config_deps,
         read_soldeer_config,
     },
     download::{clone_repo, delete_dependency_files, download_file, unzip_file},
     errors::{ConfigError, InstallError, LockError},
     lock::{
         GitLockEntry, HttpLockEntry, Integrity, LockEntry, PrivateLockEntry, forge,
-        format_install_path, generate_lockfile_contents, read_lockfile, write_lockfile,
+        format_install_path, generate_lockfile_contents, lock_for_dependency, read_lockfile,
+        write_lockfile,
     },
     registry::{DownloadUrl, get_dependency_url_remote, get_latest_supported_version},
     utils::{
@@ -269,21 +270,30 @@ impl From<GitInstallInfo> for InstallInfo {
 }
 
 impl InstallInfo {
-    async fn from_lock(
-        lock: LockEntry,
-        project_root: Option<PathBuf>,
-        zip_strip_root: bool,
-    ) -> Result<Self> {
+    /// Build the installation information for a dependency which has a matching lockfile entry.
+    async fn from_lock(lock: LockEntry, dependency: &Dependency) -> Result<Self> {
+        let project_root = dependency.project_root();
         match lock {
-            LockEntry::Http(lock) => Ok(HttpInstallInfo {
-                name: lock.name,
-                version: lock.version,
-                url: lock.url,
-                checksum: Some(lock.checksum),
-                project_root,
-                zip_strip_root,
+            LockEntry::Http(lock) => {
+                let config_url = match dependency {
+                    Dependency::Http(dep) => dep.url.clone(),
+                    Dependency::Git(_) => None,
+                };
+                let zip_strip_root = config_url.is_some();
+                let url = match config_url {
+                    Some(url) => url,
+                    None => get_dependency_url_remote(dependency, &lock.version).await?.url,
+                };
+                Ok(HttpInstallInfo {
+                    name: lock.name,
+                    version: lock.version,
+                    url,
+                    checksum: Some(lock.checksum),
+                    project_root,
+                    zip_strip_root,
+                }
+                .into())
             }
-            .into()),
             LockEntry::Git(lock) => Ok(GitInstallInfo {
                 name: lock.name,
                 version: lock.version,
@@ -294,15 +304,7 @@ impl InstallInfo {
             .into()),
             LockEntry::Private(lock) => {
                 // need to retrieve a signed download URL from the registry
-                let download = get_dependency_url_remote(
-                    &HttpDependency::builder()
-                        .name(&lock.name)
-                        .version_req(&lock.version)
-                        .build()
-                        .into(),
-                    &lock.version,
-                )
-                .await?;
+                let download = get_dependency_url_remote(dependency, &lock.version).await?;
                 Ok(Self::Private(HttpInstallInfo {
                     name: lock.name,
                     version: lock.version,
@@ -343,10 +345,10 @@ pub async fn install_dependencies(
     let mut set = JoinSet::new();
     for dep in dependencies {
         debug!(dep:% = dep; "spawning task to install dependency");
+        let lock = lock_for_dependency(locks, dep)?.cloned();
         set.spawn({
             let d = dep.clone();
             let p = progress.clone();
-            let lock = locks.iter().find(|l| l.name() == dep.name()).cloned();
             let deps = deps.as_ref().to_path_buf();
             async move {
                 install_dependency(
@@ -389,7 +391,7 @@ pub async fn install_dependencies_sequential(
     let mut results = Vec::new();
     for dep in dependencies {
         debug!(dep:% = dep; "installing dependency sequentially");
-        let lock = locks.iter().find(|l| l.name() == dep.name());
+        let lock = lock_for_dependency(locks, dep)?;
         results.push(
             install_dependency(dep, lock, deps.clone(), None, recursive_deps, progress.clone())
                 .await?,
@@ -492,14 +494,7 @@ pub async fn install_dependency(
             }
         }
         install_dependency_inner(
-            &InstallInfo::from_lock(
-                lock.clone(),
-                dependency.project_root(),
-                // custom URLs point to source archives which may wrap the contents in a root
-                // folder; registry archives never do
-                dependency.url().is_some(),
-            )
-            .await?,
+            &InstallInfo::from_lock(lock.clone(), dependency).await?,
             lock.install_path(&deps),
             recursive_deps,
             progress,

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -7,9 +7,9 @@
 //! different machines. It is also used to skip the installation of dependencies that are already
 //! installed.
 use crate::{
-    config::Dependency,
-    errors::LockError,
-    utils::{is_symlink, sanitize_filename},
+    config::{Dependency, GitIdentifier},
+    errors::{LockError, LockMismatch},
+    utils::{is_symlink, sanitize_filename, version_matches_req},
 };
 use log::{debug, warn};
 use serde::{Deserialize, Serialize};
@@ -327,6 +327,111 @@ impl LockEntry {
     pub fn as_private(&self) -> Option<&PrivateLockEntry> {
         if let Self::Private(l) = self { Some(l) } else { None }
     }
+
+    /// Check that this entry describes the dependency declared in the config file.
+    ///
+    /// The name is not checked, since entries are looked up by name in the first place. Registry
+    /// dependencies don't pin a URL in the config, so their download URL is resolved again at
+    /// install time. For git dependencies, we only check consistency with the config if a `rev` is
+    /// provided, as anything more would require talking to a remote.
+    ///
+    /// # Errors
+    /// If the entry's type, version, source URL or pinned commit disagrees with the config.
+    pub fn matches(&self, dependency: &Dependency) -> std::result::Result<(), LockMismatch> {
+        match (self, dependency) {
+            (Self::Http(lock), Dependency::Http(dep)) => {
+                check_version(&lock.version, &dep.version_req, dep.url.is_some())?;
+                if let Some(url) = &dep.url &&
+                    url != &lock.url
+                {
+                    return Err(LockMismatch::Url {
+                        locked: lock.url.clone(),
+                        required: url.clone(),
+                    });
+                }
+                Ok(())
+            }
+            (Self::Private(lock), Dependency::Http(dep)) => {
+                // private dependencies always come from the registry, so a custom URL can't match
+                if dep.url.is_some() {
+                    return Err(LockMismatch::Type {
+                        locked: "private".to_string(),
+                        required: "http".to_string(),
+                    });
+                }
+                check_version(&lock.version, &dep.version_req, false)
+            }
+            (Self::Git(lock), Dependency::Git(dep)) => {
+                check_version(&lock.version, &dep.version_req, true)?;
+                if lock.git != dep.git {
+                    return Err(LockMismatch::Git {
+                        locked: lock.git.clone(),
+                        required: dep.git.clone(),
+                    });
+                }
+                if let Some(GitIdentifier::Rev(rev)) = &dep.identifier &&
+                    rev != &lock.rev
+                {
+                    return Err(LockMismatch::Rev {
+                        locked: lock.rev.clone(),
+                        required: rev.clone(),
+                    });
+                }
+                Ok(())
+            }
+            (lock, dep) => Err(LockMismatch::Type {
+                locked: lock.kind().to_string(),
+                required: match dep {
+                    Dependency::Http(_) => "http".to_string(),
+                    Dependency::Git(_) => "git".to_string(),
+                },
+            }),
+        }
+    }
+
+    /// The kind of dependency this entry describes, for diagnostics.
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Git(_) => "git",
+            Self::Http(_) => "http",
+            Self::Private(_) => "private",
+        }
+    }
+}
+
+/// Check that a locked version is compatible with the version requirement from the config.
+///
+/// Git dependencies and HTTP dependencies with a custom URL store the requirement string verbatim
+/// as their version, since there is no registry to resolve a range against, so they are compared
+/// exactly.
+fn check_version(
+    locked: &str,
+    version_req: &str,
+    exact: bool,
+) -> std::result::Result<(), LockMismatch> {
+    let matches =
+        if exact { locked == version_req } else { version_matches_req(locked, version_req) };
+    if matches {
+        return Ok(());
+    }
+    Err(LockMismatch::Version { locked: locked.to_string(), required: version_req.to_string() })
+}
+
+/// Find the lockfile entry corresponding to a dependency from the config file.
+///
+/// # Errors
+/// If an entry exists for that dependency name but disagrees with the config.
+pub fn lock_for_dependency<'a>(
+    locks: &'a [LockEntry],
+    dependency: &Dependency,
+) -> Result<Option<&'a LockEntry>> {
+    let Some(lock) = locks.iter().find(|l| l.name() == dependency.name()) else {
+        debug!(dep:% = dependency; "no lockfile entry for dependency");
+        return Ok(None);
+    };
+    lock.matches(dependency)
+        .map_err(|source| LockError::Mismatch { dep: dependency.to_string(), source })?;
+    Ok(Some(lock))
 }
 
 impl From<HttpLockEntry> for LockEntry {
@@ -499,7 +604,157 @@ fn replace_file(contents: &str, path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{GitDependency, HttpDependency};
     use testdir::testdir;
+
+    fn http_lock(version: &str, url: &str) -> LockEntry {
+        HttpLockEntry::builder()
+            .name("mylib")
+            .version(version)
+            .url(url)
+            .checksum("dead")
+            .integrity("beef")
+            .build()
+            .into()
+    }
+
+    fn git_lock(version: &str, git: &str, rev: &str) -> LockEntry {
+        GitLockEntry::builder().name("mylib").version(version).git(git).rev(rev).build().into()
+    }
+
+    #[test]
+    fn test_check_matches_registry_version() {
+        let lock = http_lock("1.2.0", "https://example.com/mylib.zip");
+        // the lockfile records the resolved version, which must satisfy the requirement
+        for req in ["^1.0.0", "1.2.0", "*", ">=1.1.0, <2.0.0"] {
+            let dep = HttpDependency::builder().name("mylib").version_req(req).build().into();
+            assert!(lock.matches(&dep).is_ok(), "{req}");
+        }
+        for req in ["^2.0.0", "1.1.0", "=1.3.0"] {
+            let dep = HttpDependency::builder().name("mylib").version_req(req).build().into();
+            assert!(matches!(lock.matches(&dep), Err(LockMismatch::Version { .. })), "{req}");
+        }
+    }
+
+    #[test]
+    fn test_check_matches_custom_url() {
+        let lock = http_lock("1.0.0", "https://example.com/mylib.zip");
+        let dep = HttpDependency::builder()
+            .name("mylib")
+            .version_req("1.0.0")
+            .url("https://example.com/mylib.zip")
+            .build()
+            .into();
+        assert!(lock.matches(&dep).is_ok());
+
+        // a lockfile entry cannot repoint a dependency at another URL
+        let dep = HttpDependency::builder()
+            .name("mylib")
+            .version_req("1.0.0")
+            .url("https://evil.com/mylib.zip")
+            .build()
+            .into();
+        assert!(matches!(lock.matches(&dep), Err(LockMismatch::Url { .. })));
+
+        // for a custom URL the version requirement is stored verbatim, so it is compared exactly
+        let dep = HttpDependency::builder()
+            .name("mylib")
+            .version_req("^1.0.0")
+            .url("https://example.com/mylib.zip")
+            .build()
+            .into();
+        assert!(matches!(lock.matches(&dep), Err(LockMismatch::Version { .. })));
+    }
+
+    #[test]
+    fn test_check_matches_git() {
+        let rev = "78c2f6a1a54db26bab6c3f501854a1564eb3707f";
+        let lock = git_lock("1.0.0", "git@github.com:foo/bar.git", rev);
+        let dep = GitDependency::builder()
+            .name("mylib")
+            .version_req("1.0.0")
+            .git("git@github.com:foo/bar.git")
+            .build()
+            .into();
+        assert!(lock.matches(&dep).is_ok());
+
+        let dep = GitDependency::builder()
+            .name("mylib")
+            .version_req("1.0.0")
+            .git("git@github.com:evil/bar.git")
+            .build()
+            .into();
+        assert!(matches!(lock.matches(&dep), Err(LockMismatch::Git { .. })));
+
+        // an explicit rev in the config wins over the one recorded in the lockfile
+        let dep = GitDependency::builder()
+            .name("mylib")
+            .version_req("1.0.0")
+            .git("git@github.com:foo/bar.git")
+            .identifier(GitIdentifier::from_rev("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+            .build()
+            .into();
+        assert!(matches!(lock.matches(&dep), Err(LockMismatch::Rev { .. })));
+
+        // a branch can only be resolved by talking to the remote, so it is not compared
+        let dep = GitDependency::builder()
+            .name("mylib")
+            .version_req("1.0.0")
+            .git("git@github.com:foo/bar.git")
+            .identifier(GitIdentifier::from_branch("main"))
+            .build()
+            .into();
+        assert!(lock.matches(&dep).is_ok());
+    }
+
+    #[test]
+    fn test_check_matches_type() {
+        let git = git_lock("1.0.0", "git@github.com:foo/bar.git", "dead");
+        let dep = HttpDependency::builder().name("mylib").version_req("1.0.0").build().into();
+        assert!(matches!(git.matches(&dep), Err(LockMismatch::Type { .. })));
+
+        let http = http_lock("1.0.0", "https://example.com/mylib.zip");
+        let dep = GitDependency::builder()
+            .name("mylib")
+            .version_req("1.0.0")
+            .git("git@github.com:foo/bar.git")
+            .build()
+            .into();
+        assert!(matches!(http.matches(&dep), Err(LockMismatch::Type { .. })));
+
+        // private entries come from the registry, so they can't back a custom URL
+        let private: LockEntry = PrivateLockEntry::builder()
+            .name("mylib")
+            .version("1.0.0")
+            .checksum("dead")
+            .integrity("beef")
+            .build()
+            .into();
+        let dep = HttpDependency::builder().name("mylib").version_req("1.0.0").build().into();
+        assert!(private.matches(&dep).is_ok());
+        let dep = HttpDependency::builder()
+            .name("mylib")
+            .version_req("1.0.0")
+            .url("https://example.com/mylib.zip")
+            .build()
+            .into();
+        assert!(matches!(private.matches(&dep), Err(LockMismatch::Type { .. })));
+    }
+
+    #[test]
+    fn test_lock_for_dependency() {
+        let locks = vec![http_lock("1.2.0", "https://example.com/mylib.zip")];
+        let dep = HttpDependency::builder().name("mylib").version_req("^1.0.0").build().into();
+        assert!(lock_for_dependency(&locks, &dep).unwrap().is_some());
+
+        // a dependency without an entry is not an error, it just gets installed from the config
+        let dep = HttpDependency::builder().name("other").version_req("^1.0.0").build().into();
+        assert!(lock_for_dependency(&locks, &dep).unwrap().is_none());
+
+        let dep = HttpDependency::builder().name("mylib").version_req("^2.0.0").build().into();
+        let res = lock_for_dependency(&locks, &dep);
+        assert!(matches!(res, Err(LockError::Mismatch { .. })), "{res:?}");
+    }
 
     #[test]
     fn test_toml_to_lock_entry_conversion_http() {

--- a/crates/core/src/remappings.rs
+++ b/crates/core/src/remappings.rs
@@ -1,8 +1,8 @@
 //! Remappings management.
 use crate::{
     config::{Dependency, Paths, SoldeerConfig, read_config_deps},
-    errors::RemappingsError,
-    lock::read_lockfile,
+    errors::{LockError, RemappingsError},
+    lock::{LockEntry, read_lockfile},
     utils::path_matches,
 };
 use derive_more::derive::From;
@@ -218,12 +218,12 @@ fn generate_remappings(
     existing_remappings: &[(&str, &str)],
 ) -> Result<Vec<String>> {
     let mut new_remappings = Vec::new();
-    // the lockfile is read once here and the resolved paths are reused for all dependencies
-    let locked_paths = locked_install_paths(paths)?;
+    // the lockfile is read once here and the entries are reused for all dependencies
+    let locked = locked_entries(paths)?;
     if soldeer_config.remappings_regenerate {
         debug!("ignoring existing remappings and recreating from config");
         let (dependencies, _) = read_config_deps(&paths.config)?;
-        new_remappings = remappings_from_deps(&dependencies, paths, soldeer_config, &locked_paths)?
+        new_remappings = remappings_from_deps(&dependencies, paths, soldeer_config, &locked)?
             .into_iter()
             .map(|i| i.remapping_string)
             .collect();
@@ -232,7 +232,7 @@ fn generate_remappings(
             RemappingsAction::Remove(remove_dep) => {
                 debug!(dep:% = remove_dep; "trying to remove dependency from remappings");
                 // only keep items not matching the dependency to remove
-                if let Ok(remove_og) = get_install_dir_relative(remove_dep, paths, &locked_paths) {
+                if let Ok(remove_og) = get_install_dir_relative(remove_dep, paths, &locked) {
                     for (existing_remapped, existing_og) in existing_remappings {
                         // TODO: make the detection smarter, and match on any path where the version
                         // is semver-compatible too.
@@ -254,7 +254,7 @@ fn generate_remappings(
                 // we only add the remapping if it's not already existing, otherwise we keep the old
                 // remapping
                 let add_dep_remapped = format_remap_name(soldeer_config, add_dep);
-                let add_dep_og = get_install_dir_relative(add_dep, paths, &locked_paths)?;
+                let add_dep_og = get_install_dir_relative(add_dep, paths, &locked)?;
                 let mut found = false; // whether a remapping existed for that dep already
                 let n_components = install_dir_component_count(paths);
                 for (existing_remapped, existing_og) in existing_remappings {
@@ -282,7 +282,7 @@ fn generate_remappings(
                 );
                 let (dependencies, _) = read_config_deps(&paths.config)?;
                 let new_remappings_info =
-                    remappings_from_deps(&dependencies, paths, soldeer_config, &locked_paths)?;
+                    remappings_from_deps(&dependencies, paths, soldeer_config, &locked)?;
                 if existing_remappings.is_empty() {
                     debug!("no existing remappings, using the ones from config");
                     new_remappings =
@@ -361,50 +361,50 @@ fn remappings_from_deps(
     dependencies: &[Dependency],
     paths: &Paths,
     soldeer_config: &SoldeerConfig,
-    locked_paths: &HashMap<String, PathBuf>,
+    locked: &HashMap<String, LockEntry>,
 ) -> Result<Vec<RemappingInfo>> {
     dependencies
         .par_iter()
         .map(|dependency| {
             let dependency_name_formatted = format_remap_name(soldeer_config, dependency); // contains trailing slash
-            let relative_path = get_install_dir_relative(dependency, paths, locked_paths)?;
+            let relative_path = get_install_dir_relative(dependency, paths, locked)?;
             Ok((format!("{dependency_name_formatted}={relative_path}/"), dependency.clone()).into())
         })
         .collect::<Result<Vec<RemappingInfo>>>()
 }
 
-/// Map each dependency name found in the lockfile to its exact install folder.
-///
-/// Entries whose install folder is missing from disk are skipped so that callers fall back to
-/// searching the dependencies folder instead of pointing at a path which doesn't exist.
-fn locked_install_paths(paths: &Paths) -> Result<HashMap<String, PathBuf>> {
+/// Map each dependency name found in the lockfile to its entry.
+fn locked_entries(paths: &Paths) -> Result<HashMap<String, LockEntry>> {
     Ok(read_lockfile(&paths.lock)?
         .entries
         .into_iter()
-        .filter_map(|entry| {
-            let path = entry.install_path(&paths.dependencies);
-            path.exists().then(|| (entry.name().to_string(), path))
-        })
+        .map(|entry| (entry.name().to_string(), entry))
         .collect())
 }
 
-/// Find the install path (relative to project root) for a dependency that was already installed
+/// Find the install path (relative to project root) for a dependency that was already installed.
 ///
-/// The path recorded in the lockfile takes precedence, so that a semver requirement always resolves
-/// to the locked version rather than to any compatible folder left over from a previous install.
+/// The path is always derived from the lockfile entry, after checking that the entry describes the
+/// dependency declared in the config.
 ///
 /// # Errors
-/// If the there is no folder in the dependencies folder corresponding to the dependency
+/// If the dependency has no lockfile entry, if the entry disagrees with the config, or if the
+/// install folder is missing from disk.
 fn get_install_dir_relative(
     dependency: &Dependency,
     paths: &Paths,
-    locked_paths: &HashMap<String, PathBuf>,
+    locked_entries: &HashMap<String, LockEntry>,
 ) -> Result<String> {
-    let path = locked_paths
+    let entry = locked_entries
         .get(dependency.name())
-        .cloned()
-        .or_else(|| dependency.install_path_sync(&paths.dependencies))
         .ok_or_else(|| RemappingsError::DependencyNotFound(dependency.to_string()))?;
+    entry
+        .matches(dependency)
+        .map_err(|source| LockError::Mismatch { dep: dependency.to_string(), source })?;
+    let path = entry.install_path(&paths.dependencies);
+    if !path.exists() {
+        return Err(RemappingsError::DependencyNotFound(dependency.to_string()));
+    }
     let path = dunce::canonicalize(path)?;
     Ok(path
         .strip_prefix(&paths.root) // already canonicalized
@@ -472,11 +472,17 @@ mod tests {
         let dependencies_dir = dir.join("dependencies");
         fs::create_dir_all(&dependencies_dir).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
+        fs::write(
+            &paths.lock,
+            format!("{}{}", lockfile_contents("dep1", "1.1.1"), git_lockfile_contents("dep2")),
+        )
+        .unwrap();
+        let locked = locked_entries(&paths).unwrap();
 
         fs::create_dir_all(dependencies_dir.join("dep1-1.1.1")).unwrap();
         let dependency =
             HttpDependency::builder().name("dep1").version_req("^1.0.0").build().into();
-        let res = get_install_dir_relative(&dependency, &paths, &HashMap::new());
+        let res = get_install_dir_relative(&dependency, &paths, &locked);
         assert!(res.is_ok(), "{res:?}");
         assert_eq!(res.unwrap(), "dependencies/dep1-1.1.1");
 
@@ -487,12 +493,12 @@ mod tests {
             .git("git@github.com:test/test.git")
             .build()
             .into();
-        let res = get_install_dir_relative(&dependency, &paths, &HashMap::new());
+        let res = get_install_dir_relative(&dependency, &paths, &locked);
         assert!(res.is_ok(), "{res:?}");
         assert_eq!(res.unwrap(), "dependencies/dep2-2.0.0");
 
         let dependency = HttpDependency::builder().name("dep3").version_req("3.0.0").build().into();
-        let res = get_install_dir_relative(&dependency, &paths, &HashMap::new());
+        let res = get_install_dir_relative(&dependency, &paths, &locked);
         assert!(res.is_err(), "{res:?}");
     }
 
@@ -507,8 +513,7 @@ mod tests {
         let dependency =
             HttpDependency::builder().name("dep1").version_req("^1.0.0").build().into();
 
-        let res =
-            get_install_dir_relative(&dependency, &paths, &locked_install_paths(&paths).unwrap());
+        let res = get_install_dir_relative(&dependency, &paths, &locked_entries(&paths).unwrap());
         assert!(res.is_ok(), "{res:?}");
         assert_eq!(res.unwrap(), "dependencies/dep1-1.2.0");
     }
@@ -518,33 +523,50 @@ mod tests {
         let dir = testdir!();
         fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
         let paths = Paths::from_root(&dir).unwrap();
+        // a compatible folder is present on disk but it is not the locked one, so it must not be
+        // picked up
         fs::create_dir_all(paths.dependencies.join("dep1-1.1.1")).unwrap();
-        // the locked version was never installed, we fall back to the compatible folder on disk
         fs::write(&paths.lock, lockfile_contents("dep1", "1.2.0")).unwrap();
         let dependency =
             HttpDependency::builder().name("dep1").version_req("^1.0.0").build().into();
 
-        let res =
-            get_install_dir_relative(&dependency, &paths, &locked_install_paths(&paths).unwrap());
-        assert!(res.is_ok(), "{res:?}");
-        assert_eq!(res.unwrap(), "dependencies/dep1-1.1.1");
+        let res = get_install_dir_relative(&dependency, &paths, &locked_entries(&paths).unwrap());
+        assert!(matches!(res, Err(RemappingsError::DependencyNotFound(_))), "{res:?}");
     }
 
     #[test]
-    fn test_locked_install_paths() {
+    fn test_get_install_dir_relative_rejects_mismatched_lock() {
         let dir = testdir!();
         fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("dep1-1.2.0")).unwrap();
+        fs::write(&paths.lock, lockfile_contents("dep1", "1.2.0")).unwrap();
+        // the config requires a version the lockfile entry does not satisfy
+        let dependency =
+            HttpDependency::builder().name("dep1").version_req("^2.0.0").build().into();
+
+        let res = get_install_dir_relative(&dependency, &paths, &locked_entries(&paths).unwrap());
+        assert!(
+            matches!(res, Err(RemappingsError::LockError(LockError::Mismatch { .. }))),
+            "{res:?}"
+        );
+    }
+
+    #[test]
+    fn test_locked_entries() {
+        let dir = testdir!();
+        fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+        let paths = Paths::from_root(&dir).unwrap();
         fs::write(
             &paths.lock,
             format!("{}{}", lockfile_contents("dep1", "1.2.0"), lockfile_contents("dep2", "2.0.0")),
         )
         .unwrap();
 
-        let res = locked_install_paths(&paths).unwrap();
-        assert_eq!(res.len(), 1);
-        assert_eq!(res.get("dep1"), Some(&paths.dependencies.join("dep1-1.2.0")));
+        let res = locked_entries(&paths).unwrap();
+        assert_eq!(res.len(), 2);
+        assert_eq!(res.get("dep1").map(LockEntry::version), Some("1.2.0"));
+        assert_eq!(res.get("dep2").map(LockEntry::version), Some("2.0.0"));
     }
 
     fn lockfile_contents(name: &str, version: &str) -> String {
@@ -555,6 +577,28 @@ version = "{version}"
 url = "https://example.com/{name}.zip"
 checksum = "checksum"
 integrity = "integrity"
+"#
+        )
+    }
+
+    /// Write a lockfile containing one HTTP entry per `(name, version)` pair.
+    fn write_lock(paths: &Paths, deps: &[(&str, &str)]) {
+        let contents: String =
+            deps.iter().map(|(name, version)| lockfile_contents(name, version)).collect();
+        fs::write(&paths.lock, contents).unwrap();
+    }
+
+    fn git_lockfile_contents(name: &str) -> String {
+        git_lockfile_contents_version(name, "2.0.0")
+    }
+
+    fn git_lockfile_contents_version(name: &str, version: &str) -> String {
+        format!(
+            r#"[[dependencies]]
+name = "{name}"
+version = "{version}"
+git = "git@github.com:test/test.git"
+rev = "78c2f6a1a54db26bab6c3f501854a1564eb3707f"
 "#
         )
     }
@@ -629,10 +673,20 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
         fs::create_dir_all(dependencies_dir.join("dep1-1.1.1")).unwrap();
         fs::create_dir_all(dependencies_dir.join("dep2-2.0.0")).unwrap();
         fs::create_dir_all(dependencies_dir.join("dep3-foobar")).unwrap();
+        fs::write(
+            &paths.lock,
+            format!(
+                "{}{}{}",
+                lockfile_contents("dep1", "1.1.1"),
+                lockfile_contents("dep2", "2.0.0"),
+                git_lockfile_contents_version("dep3", "foobar")
+            ),
+        )
+        .unwrap();
 
         let (dependencies, _) = read_config_deps(&paths.config).unwrap();
-        let res =
-            remappings_from_deps(&dependencies, &paths, &SoldeerConfig::default(), &HashMap::new());
+        let locked = locked_entries(&paths).unwrap();
+        let res = remappings_from_deps(&dependencies, &paths, &SoldeerConfig::default(), &locked);
         assert!(res.is_ok(), "{res:?}");
         let res = res.unwrap();
         assert_eq!(res.len(), 3);
@@ -647,6 +701,7 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
         fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0"), ("lib2", "1.1.1")]);
         let config = SoldeerConfig::default();
         // empty existing remappings
         let existing_deps = vec![];
@@ -693,6 +748,7 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib2-2.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0"), ("lib2", "2.0.0")]);
         let config = SoldeerConfig::default();
         let existing_deps = vec![
             ("lib1-1.0.0/", "dependencies/lib1-1.0.0/"),
@@ -726,6 +782,7 @@ lib2 = "2.0.0"
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib2-2.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0"), ("lib2", "2.0.0")]);
         let config = SoldeerConfig::default();
         // all entries are customized
         let existing_deps = vec![
@@ -777,6 +834,7 @@ lib1 = "1.0.0"
         fs::write(dir.join("foundry.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
         let config = SoldeerConfig::default();
         let res = remappings_foundry(&RemappingsAction::Update, &paths, &config);
         assert!(res.is_ok(), "{res:?}");
@@ -806,6 +864,7 @@ lib1 = "1.0.0"
         fs::write(dir.join("foundry.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
         let config = SoldeerConfig::default();
         // should only add remappings to the default profile
         let res = remappings_foundry(&RemappingsAction::Update, &paths, &config);
@@ -839,6 +898,7 @@ lib1 = "1.0.0"
         fs::write(dir.join("foundry.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
         let config = SoldeerConfig::default();
         let res = remappings_foundry(&RemappingsAction::Update, &paths, &config);
         assert!(res.is_ok(), "{res:?}");
@@ -876,6 +936,7 @@ lib1 = "1.0.0"
         fs::write(dir.join("foundry.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
         let config = SoldeerConfig::default();
         let res = remappings_foundry(&RemappingsAction::Update, &paths, &config);
         assert!(res.is_ok(), "{res:?}");
@@ -901,6 +962,7 @@ lib1 = "1.0.0"
         fs::write(dir.join("soldeer.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
         let remappings = "lib1/=dependencies/lib1-1.0.0/src/\n";
         fs::write(dir.join("remappings.txt"), remappings).unwrap();
         let config = SoldeerConfig::default();
@@ -919,6 +981,7 @@ lib1 = "1.0.0"
         fs::write(dir.join("soldeer.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
         let remappings = "lib1/=dependencies/lib1-1.0.0/src/\n";
         fs::write(dir.join("remappings.txt"), remappings).unwrap();
         let config = SoldeerConfig { remappings_regenerate: true, ..Default::default() };
@@ -982,6 +1045,7 @@ lib2 = "2.0.0"
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib2-2.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0"), ("lib2", "2.0.0")]);
         let remappings = "lib1/=dependencies/lib1-1.0.0/src/\n";
         fs::write(dir.join("remappings.txt"), remappings).unwrap();
         let config = SoldeerConfig::default();
@@ -1003,6 +1067,7 @@ lib1 = "1.0.0"
         fs::write(dir.join("soldeer.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
         // the config gets ignored in this case
         let config =
             SoldeerConfig { remappings_location: RemappingsLocation::Config, ..Default::default() };
@@ -1024,6 +1089,7 @@ lib1 = "1.0.0"
         fs::write(dir.join("foundry.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib1-1.0.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
         fs::write(&paths.remappings, "lib1/=dependencies/lib1-old/\n").unwrap();
         let config =
             SoldeerConfig { remappings_location: RemappingsLocation::Config, ..Default::default() };
@@ -1047,6 +1113,7 @@ lib2 = "2"
         // libs have been updated to newer versions
         fs::create_dir_all(paths.dependencies.join("lib1-1.2.0")).unwrap();
         fs::create_dir_all(paths.dependencies.join("lib2-2.1.0")).unwrap();
+        write_lock(&paths, &[("lib1", "1.2.0"), ("lib2", "2.1.0")]);
         let config = SoldeerConfig::default();
         // all entries are customized, using an old version of the libs
         let existing_deps = vec![
@@ -1078,6 +1145,7 @@ libs = ["dependencies"]
         fs::write(dir.join("foundry.toml"), contents).unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         fs::create_dir_all(paths.dependencies.join("@openzeppelin-contracts-5.0.2")).unwrap();
+        write_lock(&paths, &[("@openzeppelin-contracts", "5.0.2")]);
         let res = remappings_foundry(
             &RemappingsAction::Update,
             &paths,

--- a/crates/core/src/update.rs
+++ b/crates/core/src/update.rs
@@ -43,7 +43,13 @@ pub async fn update_dependencies(
             let d = dep.clone();
             let p = progress.clone();
 
-            let lock = locks.iter().find(|l| l.name() == dep.name()).cloned();
+            // during updating, we skip lockfile entries which do not match on all criteria, so we
+            // can generate a new lockfile that corresponds to the updated config entry.
+            let lock = locks
+                .iter()
+                .find(|l| l.name() == dep.name())
+                .filter(|l| l.matches(dep).is_ok())
+                .cloned();
             let paths = deps_path.as_ref().to_path_buf();
             async move { update_dependency(&d, lock.as_ref(), &paths, recursive_deps, p).await }
         });

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -329,18 +329,22 @@ pub fn path_matches(dependency: &Dependency, path: impl AsRef<Path>) -> bool {
     };
     let dir_name = dir_name.to_string_lossy();
     let prefix = format!("{}-", sanitize_filename(dependency.name()));
-    if !dir_name.starts_with(&prefix) {
+    let Some(version) = dir_name.strip_prefix(&prefix) else {
         return false;
-    }
-    match (
-        parse_version_req(dependency.version_req()),
-        Version::parse(dir_name.strip_prefix(&prefix).expect("prefix should be present")),
-    ) {
+    };
+    version_matches_req(version, dependency.version_req())
+}
+
+/// Check if a resolved version satisfies a dependency's version requirement.
+///
+/// If either side is not semver compliant, the two strings are compared after sanitization, since
+/// that is the form in which non-semver versions appear in folder names.
+pub fn version_matches_req(version: &str, version_req: &str) -> bool {
+    match (parse_version_req(version_req), Version::parse(version)) {
+        (Some(req), Ok(version)) => req.matches(&version),
         (None, _) | (Some(_), Err(_)) => {
-            // not semver compliant
-            dir_name == format!("{prefix}{}", sanitize_filename(dependency.version_req()))
+            sanitize_filename(version) == sanitize_filename(version_req)
         }
-        (Some(version_req), Ok(version)) => version_req.matches(&version),
     }
 }
 


### PR DESCRIPTION
The tool now errors out if there's a mismatch between a dependency's config item (in soldeer.toml or foundry.toml) and the resolved lockfile entry (resolved by name). This means users will be forced to call `soldeer update` if they change the TOML config, which is exactly what we want. Otherwise, if the integrity check succeeds, we might still install an outdated version without the user noticing.