### PR TITLE
fix: errors sometimes not showing properly

### DIFF
--- a/crates/commands/src/commands/install.rs
+++ b/crates/commands/src/commands/install.rs
@@ -130,7 +130,10 @@ pub(crate) async fn install_command(paths: &Paths, cmd: Install) -> Result<()> {
                 config.recursive_deps,
                 progress,
             )
-            .await?;
+            .await
+            .inspect_err(|e| {
+                bars.set_error(e);
+            })?;
             bars.stop_all();
             let new_lockfile_content = generate_lockfile_contents(new_locks);
             if !lockfile.raw.is_empty() && new_lockfile_content != lockfile.raw {
@@ -182,7 +185,10 @@ pub(crate) async fn install_command(paths: &Paths, cmd: Install) -> Result<()> {
                 config.recursive_deps,
                 progress,
             )
-            .await?;
+            .await
+            .inspect_err(|e| {
+                bars.set_error(e);
+            })?;
             bars.stop_all();
             // for git deps, we need to add the commit hash before adding them to the
             // config, unless a branch/tag was specified

--- a/crates/commands/src/commands/update.rs
+++ b/crates/commands/src/commands/update.rs
@@ -68,7 +68,10 @@ pub(crate) async fn update_command(paths: &Paths, cmd: Update) -> Result<()> {
         config.recursive_deps,
         progress,
     )
-    .await?;
+    .await
+    .inspect_err(|e| {
+        bars.set_error(e);
+    })?;
     bars.stop_all();
 
     let new_lockfile_content = generate_lockfile_contents(new_locks);

--- a/crates/commands/src/utils.rs
+++ b/crates/commands/src/utils.rs
@@ -1,6 +1,13 @@
 #![allow(unused_macros)]
 //! Utils for the commands crate
-use std::{fmt, path::Path};
+use std::{
+    fmt,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use crate::ConfigLocation;
 use cliclack::{MultiProgress, ProgressBar, multi_progress, progress_bar, select};
@@ -18,6 +25,7 @@ pub struct Progress {
     unzip: Option<ProgressBar>,
     subdependencies: Option<ProgressBar>,
     integrity: Option<ProgressBar>,
+    stopped: Arc<AtomicBool>,
 }
 
 impl Progress {
@@ -103,6 +111,7 @@ impl Progress {
             unzip: Some(unzip),
             subdependencies: Some(subdependencies),
             integrity: Some(integrity),
+            stopped: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -117,6 +126,7 @@ impl Progress {
 
     /// Stop all progress bars.
     pub fn stop_all(&self) {
+        self.stopped.store(true, Ordering::Relaxed);
         self.versions.as_ref().inspect(|p| p.stop("Done retrieving versions"));
         self.downloads.as_ref().inspect(|p| p.stop("Done downloading dependencies"));
         self.unzip.as_ref().inspect(|p| p.stop("Done unzipping dependencies"));
@@ -125,8 +135,20 @@ impl Progress {
         self.multi.as_ref().inspect(|p| p.stop());
     }
 
+    /// Stop all progress bars and render the header in the error state.
     pub fn set_error(&self, error: impl fmt::Display) {
+        self.stopped.store(true, Ordering::Relaxed);
         self.multi.as_ref().inspect(|m| m.error(error));
+    }
+}
+
+impl Drop for Progress {
+    fn drop(&mut self) {
+        // the bars keep a render thread alive which repaints over anything printed to stderr, so
+        // an early return that skips `stop_all`/`set_error` would hide the error message
+        if !self.stopped.swap(true, Ordering::Relaxed) {
+            self.multi.as_ref().inspect(|m| m.cancel());
+        }
     }
 }
 


### PR DESCRIPTION
Errors were sometimes propagated without correctly interrupting the progress bars drawing, which make the error hidden below the progress bars.
