### PR TITLE
feat(remappings): infer source directory suffix like forge

### DIFF
--- a/crates/commands/tests/tests-install.rs
+++ b/crates/commands/tests/tests-install.rs
@@ -979,7 +979,7 @@ remappings_regenerate = true
 src = "src"
 out = "out"
 libs = ["dependencies"]
-remappings = ["@custom-f@forge-std-1.8.1/=dependencies/forge-std-1.8.1/"]
+remappings = ["@custom-f@forge-std-1.8.1/=dependencies/forge-std-1.8.1/src/"]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 
@@ -1022,7 +1022,7 @@ remappings_location = "config"
 
     let expected = r#"[profile.default]
 libs = ["dependencies"]
-remappings = ["!custom-f!forge-std-1.8.1/=dependencies/forge-std-1.8.1/"]
+remappings = ["!custom-f!forge-std-1.8.1/=dependencies/forge-std-1.8.1/src/"]
 
 [soldeer]
 remappings_prefix = "!custom-f!"
@@ -1062,7 +1062,7 @@ remappings_regenerate = true
     .await;
     assert!(res.is_ok(), "{res:?}");
 
-    let updated_contents = r#"!custom-f!forge-std-1.8.1/=dependencies/forge-std-1.8.1/
+    let updated_contents = r#"!custom-f!forge-std-1.8.1/=dependencies/forge-std-1.8.1/src/
 "#;
 
     assert_eq!(updated_contents, fs::read_to_string(dir.join("remappings.txt")).unwrap());

--- a/crates/core/src/remappings.rs
+++ b/crates/core/src/remappings.rs
@@ -14,7 +14,7 @@ use std::{
     collections::HashMap,
     fs::{self, File},
     io::Write as _,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 use toml_edit::{Array, DocumentMut, value};
 
@@ -270,7 +270,8 @@ fn generate_remappings(
                 }
                 if !found {
                     debug!(dep:% = add_dep; "remapping not found, adding it");
-                    new_remappings.push(format!("{add_dep_remapped}={add_dep_og}/"));
+                    let suffix = source_dir_suffix(&paths.root.join(&add_dep_og));
+                    new_remappings.push(format!("{add_dep_remapped}={add_dep_og}/{suffix}"));
                 }
             }
             RemappingsAction::Update => {
@@ -311,9 +312,14 @@ fn generate_remappings(
                                     .components()
                                     .take(n_components)
                                     .collect();
+                                // Replace only the install-directory portion so the user's
+                                // own suffix (or its deliberate absence) is preserved: the
+                                // inferred source suffix in `item_og` must not leak in here.
+                                let new_install_dir: PathBuf =
+                                    PathBuf::from(item_og).components().take(n_components).collect();
                                 let existing_og_updated = existing_og.replace(
                                     path.to_slash_lossy().as_ref(),
-                                    item_og.trim_end_matches('/'),
+                                    new_install_dir.to_slash_lossy().as_ref(),
                                 );
                                 debug!(new_path = existing_og_updated; "updated remapping path");
                                 new_remappings
@@ -368,7 +374,12 @@ fn remappings_from_deps(
         .map(|dependency| {
             let dependency_name_formatted = format_remap_name(soldeer_config, dependency); // contains trailing slash
             let relative_path = get_install_dir_relative(dependency, paths, locked)?;
-            Ok((format!("{dependency_name_formatted}={relative_path}/"), dependency.clone()).into())
+            let suffix = source_dir_suffix(&paths.root.join(&relative_path));
+            Ok((
+                format!("{dependency_name_formatted}={relative_path}/{suffix}"),
+                dependency.clone(),
+            )
+                .into())
         })
         .collect::<Result<Vec<RemappingInfo>>>()
 }
@@ -380,6 +391,26 @@ fn locked_entries(paths: &Paths) -> Result<HashMap<String, LockEntry>> {
         .into_iter()
         .map(|entry| (entry.name().to_string(), entry))
         .collect())
+}
+
+/// Common Solidity source subdirectories, in the order Foundry probes them.
+const SOURCE_SUBDIRS: [&str; 2] = ["src", "contracts"];
+
+/// Infer the source subdirectory of an installed dependency so remappings point
+/// at canonical import paths, matching how `forge remappings` behaves (e.g.
+/// `forge-std/=dependencies/forge-std-1.9.4/src/` rather than the dependency
+/// root). Returns the segment to append with a trailing slash (e.g. `"src/"`),
+/// or an empty string when no known source subdirectory exists.
+///
+/// This is only applied when a remapping is first generated; the update logic
+/// preserves whatever suffix the user has, so a manually removed `src/` will not
+/// come back.
+fn source_dir_suffix(install_dir: &Path) -> String {
+    SOURCE_SUBDIRS
+        .into_iter()
+        .find(|sub| install_dir.join(sub).is_dir())
+        .map(|sub| format!("{sub}/"))
+        .unwrap_or_default()
 }
 
 /// Find the install path (relative to project root) for a dependency that was already installed.
@@ -693,6 +724,45 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
         assert_eq!(res[0].remapping_string, "dep1-^1.0.0/=dependencies/dep1-1.1.1/");
         assert_eq!(res[1].remapping_string, "dep2-2.0.0/=dependencies/dep2-2.0.0/");
         assert_eq!(res[2].remapping_string, "dep3-foobar/=dependencies/dep3-foobar/");
+    }
+
+    #[test]
+    fn test_generate_remappings_add_infers_source_dir() {
+        let dir = testdir!();
+        fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
+        let paths = Paths::from_root(&dir).unwrap();
+        // lib1 ships its Solidity under `src/`, lib2 has no known source subdir.
+        fs::create_dir_all(paths.dependencies.join("lib1-1.0.0").join("src")).unwrap();
+        fs::create_dir_all(paths.dependencies.join("lib2-1.1.1")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0"), ("lib2", "1.1.1")]);
+        let config = SoldeerConfig::default();
+
+        // A dependency with a `src/` directory gets the canonical suffix.
+        let dep = HttpDependency::builder().name("lib1").version_req("1.0.0").build().into();
+        let res = generate_remappings(&RemappingsAction::Add(dep), &paths, &config, &[]).unwrap();
+        assert_eq!(res, vec!["lib1-1.0.0/=dependencies/lib1-1.0.0/src/"]);
+
+        // A dependency without a known source subdir stays at the root.
+        let dep = HttpDependency::builder().name("lib2").version_req("1.1.1").build().into();
+        let res = generate_remappings(&RemappingsAction::Add(dep), &paths, &config, &[]).unwrap();
+        assert_eq!(res, vec!["lib2-1.1.1/=dependencies/lib2-1.1.1/"]);
+    }
+
+    #[test]
+    fn test_generate_remappings_update_keeps_user_removed_source_suffix() {
+        // The inferred suffix must not be permanent: even though lib1 ships a
+        // `src/` directory, if the user removed the auto-detected suffix from
+        // their remapping, updating must not bring it back.
+        let dir = testdir!();
+        fs::write(dir.join("soldeer.toml"), "[dependencies]\nlib1 = \"1.0.0\"\n").unwrap();
+        let paths = Paths::from_root(&dir).unwrap();
+        fs::create_dir_all(paths.dependencies.join("lib1-1.0.0").join("src")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
+        let config = SoldeerConfig::default();
+
+        let existing_deps = vec![("lib1-1.0.0/", "dependencies/lib1-1.0.0/")];
+        let res = generate_remappings(&RemappingsAction::Update, &paths, &config, &existing_deps);
+        assert_eq!(res.unwrap(), vec!["lib1-1.0.0/=dependencies/lib1-1.0.0/"]);
     }
 
     #[test]

--- a/crates/core/src/remappings.rs
+++ b/crates/core/src/remappings.rs
@@ -360,9 +360,15 @@ struct RemappingInfo {
 
 /// Generate remappings from the dependencies list.
 ///
-/// The remappings are generated in the form `alias/=path/`, where `alias` is the dependency name
-/// with an optional prefix and version requirement suffix, and `path` is the relative path to the
-/// dependency folder.
+/// The remappings are generated in the form `alias/=path/suffix`, where `alias` is the dependency
+/// name with an optional prefix and version requirement suffix, `path` is the relative path to the
+/// dependency folder, and `suffix` is the inferred source subdirectory (e.g. `src/`) when the
+/// package ships one (see [`source_dir_suffix`]).
+///
+/// This is the shared construction path used by install (`Add`), update and regenerate, so the
+/// inferred shape is identical regardless of how a dependency was installed. Preserving a suffix the
+/// user set (or deliberately removed) is handled by the caller when merging with existing entries;
+/// this function always produces the canonical, freshly-inferred shape.
 fn remappings_from_deps(
     dependencies: &[Dependency],
     paths: &Paths,
@@ -374,11 +380,9 @@ fn remappings_from_deps(
         .map(|dependency| {
             let dependency_name_formatted = format_remap_name(soldeer_config, dependency); // contains trailing slash
             let relative_path = get_install_dir_relative(dependency, paths, locked)?;
-            // The source-dir suffix is inferred only on install (`Add`). On update we
-            // must not reintroduce a `src/` the user deliberately removed, and the
-            // path must not depend on whether a remappings file already existed.
+            let suffix = source_dir_suffix(&paths.root.join(&relative_path));
             Ok((
-                format!("{dependency_name_formatted}={relative_path}/"),
+                format!("{dependency_name_formatted}={relative_path}/{suffix}"),
                 dependency.clone(),
             )
                 .into())
@@ -395,24 +399,88 @@ fn locked_entries(paths: &Paths) -> Result<HashMap<String, LockEntry>> {
         .collect())
 }
 
-/// Common Solidity source subdirectories, in the order Foundry probes them.
+/// Common Solidity source subdirectory names, in the order Foundry probes them.
 const SOURCE_SUBDIRS: [&str; 2] = ["src", "contracts"];
 
 /// Infer the source subdirectory of an installed dependency so remappings point
 /// at canonical import paths, matching how `forge remappings` behaves (e.g.
 /// `forge-std/=dependencies/forge-std-1.9.4/src/` rather than the dependency
 /// root). Returns the segment to append with a trailing slash (e.g. `"src/"`),
-/// or an empty string when no known source subdirectory exists.
+/// or an empty string when no known source subdirectory qualifies.
 ///
-/// This is only applied when a remapping is first generated; the update logic
-/// preserves whatever suffix the user has, so a manually removed `src/` will not
-/// come back.
+/// A candidate subdirectory is only chosen if it actually contains Solidity
+/// sources **and** the package root does not: a package that ships flat `.sol`
+/// files at its root (possibly alongside an unrelated `src/` used by JS/TS
+/// tooling) must be remapped at the root, not into that directory.
+///
+/// The match is case-insensitive on the directory name (to tolerate `Src/` or
+/// `Contracts/` on case-insensitive file systems), but the real on-disk name is
+/// emitted, so case-sensitive file systems keep working.
+///
+/// This shape is produced whenever a remapping is freshly generated (install,
+/// update of a new dependency, or regenerate). The update merge logic preserves
+/// whatever suffix the user already had, so a manually removed `src/` will not
+/// come back on a plain update.
 fn source_dir_suffix(install_dir: &Path) -> String {
-    SOURCE_SUBDIRS
-        .into_iter()
-        .find(|sub| install_dir.join(sub).is_dir())
-        .map(|sub| format!("{sub}/"))
-        .unwrap_or_default()
+    // A candidate subdir only wins if the root itself has no top-level `.sol`.
+    if dir_has_sol_file(install_dir) {
+        return String::new();
+    }
+    let Ok(entries) = fs::read_dir(install_dir) else {
+        return String::new();
+    };
+    // Collect subdirectories once, then probe them in Foundry's preferred order.
+    let subdirs: Vec<_> = entries
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .map(|e| e.file_name())
+        .collect();
+    for candidate in SOURCE_SUBDIRS {
+        let Some(name) = subdirs.iter().find(|n| n.eq_ignore_ascii_case(candidate)) else {
+            continue;
+        };
+        let sub = install_dir.join(name);
+        if dir_contains_sol_file(&sub) {
+            // Emit the real folder name (e.g. `Src`), not the hard-coded lowercase one.
+            return format!("{}/", name.to_string_lossy());
+        }
+    }
+    String::new()
+}
+
+/// Whether a file name has a (case-insensitive) `.sol` extension.
+fn is_sol_file(name: &std::ffi::OsStr) -> bool {
+    Path::new(name).extension().is_some_and(|ext| ext.eq_ignore_ascii_case("sol"))
+}
+
+/// Whether a directory contains at least one `.sol` file directly in it.
+fn dir_has_sol_file(dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    entries
+        .flatten()
+        .any(|e| e.file_type().is_ok_and(|t| t.is_file()) && is_sol_file(&e.file_name()))
+}
+
+/// Whether a directory contains at least one `.sol` file anywhere in its tree.
+fn dir_contains_sol_file(dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            if dir_contains_sol_file(&entry.path()) {
+                return true;
+            }
+        } else if file_type.is_file() && is_sol_file(&entry.file_name()) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Find the install path (relative to project root) for a dependency that was already installed.
@@ -614,6 +682,13 @@ integrity = "integrity"
         )
     }
 
+    /// Create `dir` (and parents) and drop a minimal `.sol` file inside it so the
+    /// source-dir heuristic recognizes it as containing Solidity sources.
+    fn create_dir_with_sol(dir: &Path) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("Contract.sol"), "// SPDX\n").unwrap();
+    }
+
     /// Write a lockfile containing one HTTP entry per `(name, version)` pair.
     fn write_lock(paths: &Paths, deps: &[(&str, &str)]) {
         let contents: String =
@@ -734,7 +809,7 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
         fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();
         let paths = Paths::from_root(&dir).unwrap();
         // lib1 ships its Solidity under `src/`, lib2 has no known source subdir.
-        fs::create_dir_all(paths.dependencies.join("lib1-1.0.0").join("src")).unwrap();
+        create_dir_with_sol(&paths.dependencies.join("lib1-1.0.0").join("src"));
         fs::create_dir_all(paths.dependencies.join("lib2-1.1.1")).unwrap();
         write_lock(&paths, &[("lib1", "1.0.0"), ("lib2", "1.1.1")]);
         let config = SoldeerConfig::default();
@@ -758,7 +833,7 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
         let dir = testdir!();
         fs::write(dir.join("soldeer.toml"), "[dependencies]\nlib1 = \"1.0.0\"\n").unwrap();
         let paths = Paths::from_root(&dir).unwrap();
-        fs::create_dir_all(paths.dependencies.join("lib1-1.0.0").join("src")).unwrap();
+        create_dir_with_sol(&paths.dependencies.join("lib1-1.0.0").join("src"));
         write_lock(&paths, &[("lib1", "1.0.0")]);
         let config = SoldeerConfig::default();
 
@@ -768,35 +843,87 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
     }
 
     #[test]
-    fn test_generate_remappings_regenerate_keeps_user_removed_source_suffix() {
-        // Same invariant as above, but with `remappings_regenerate` enabled: the
-        // suffix must not come back there either, otherwise every install,
-        // update or uninstall silently rewrites the user's remappings.
+    fn test_generate_remappings_regenerate_reinfers_source_suffix() {
+        // `remappings_regenerate` throws the existing file away, so there is no
+        // user intent to preserve: the suffix must be re-inferred from disk.
+        // (Note: in the real flow the file is deleted before `generate_remappings`
+        // is called, so `existing_remappings` is empty; the regenerate branch
+        // ignores it in any case and rebuilds from the config.)
         let dir = testdir!();
         fs::write(dir.join("soldeer.toml"), "[dependencies]\nlib1 = \"1.0.0\"\n").unwrap();
         let paths = Paths::from_root(&dir).unwrap();
-        fs::create_dir_all(paths.dependencies.join("lib1-1.0.0").join("src")).unwrap();
+        create_dir_with_sol(&paths.dependencies.join("lib1-1.0.0").join("src"));
         write_lock(&paths, &[("lib1", "1.0.0")]);
         let config = SoldeerConfig { remappings_regenerate: true, ..Default::default() };
 
+        // Even with an existing suffix-less entry, regenerate re-infers `src/`.
         let existing_deps = vec![("lib1-1.0.0/", "dependencies/lib1-1.0.0/")];
         let res = generate_remappings(&RemappingsAction::Update, &paths, &config, &existing_deps);
-        assert_eq!(res.unwrap(), vec!["lib1-1.0.0/=dependencies/lib1-1.0.0/"]);
+        assert_eq!(res.unwrap(), vec!["lib1-1.0.0/=dependencies/lib1-1.0.0/src/"]);
+    }
+
+    #[test]
+    fn test_generate_remappings_add_update_agree_for_new_dep() {
+        // A dependency must get the same remapping shape regardless of whether it
+        // was installed by name (`Add`) or via the config + install/update
+        // (`Update` with no pre-existing entry for it).
+        let dir = testdir!();
+        fs::write(dir.join("soldeer.toml"), "[dependencies]\nlib1 = \"1.0.0\"\n").unwrap();
+        let paths = Paths::from_root(&dir).unwrap();
+        create_dir_with_sol(&paths.dependencies.join("lib1-1.0.0").join("src"));
+        write_lock(&paths, &[("lib1", "1.0.0")]);
+        let config = SoldeerConfig::default();
+
+        let dep = HttpDependency::builder().name("lib1").version_req("1.0.0").build().into();
+        let added = generate_remappings(&RemappingsAction::Add(dep), &paths, &config, &[]).unwrap();
+        let updated = generate_remappings(&RemappingsAction::Update, &paths, &config, &[]).unwrap();
+        assert_eq!(added, updated);
+        assert_eq!(added, vec!["lib1-1.0.0/=dependencies/lib1-1.0.0/src/"]);
+    }
+
+    #[test]
+    fn test_source_dir_suffix_ignores_root_sol_and_capitalized_dir() {
+        let dir = testdir!();
+        // Package ships flat `.sol` at the root alongside an unrelated `src/`
+        // (e.g. JS tooling): must not be remapped into `src/`.
+        let flat = dir.join("flat");
+        fs::create_dir_all(flat.join("src")).unwrap();
+        fs::write(flat.join("Contract.sol"), "// SPDX\n").unwrap();
+        fs::write(flat.join("src").join("index.js"), "// js\n").unwrap();
+        assert_eq!(source_dir_suffix(&flat), "");
+
+        // A `src/` with no `.sol` anywhere does not qualify.
+        let empty = dir.join("empty");
+        fs::create_dir_all(empty.join("src")).unwrap();
+        fs::write(empty.join("src").join("readme.txt"), "x\n").unwrap();
+        assert_eq!(source_dir_suffix(&empty), "");
+
+        // A capitalized `Src/` containing sources: match case-insensitively but
+        // emit the real on-disk name.
+        let cap = dir.join("cap");
+        create_dir_with_sol(&cap.join("Src"));
+        assert_eq!(source_dir_suffix(&cap), "Src/");
+
+        // `contracts/` is probed after `src/`; a nested `.sol` counts.
+        let nested = dir.join("nested");
+        create_dir_with_sol(&nested.join("contracts").join("token"));
+        assert_eq!(source_dir_suffix(&nested), "contracts/");
     }
 
     #[test]
     fn test_generate_remappings_update_suffix_is_consistent() {
         // The path a dependency is remapped to must not depend on whether a
         // remappings file happened to exist: generating from scratch and
-        // merging into existing remappings have to agree.
+        // merging into an existing entry that already carries the inferred
+        // suffix have to agree.
         let dir = testdir!();
         fs::write(dir.join("soldeer.toml"), "[dependencies]\nlib1 = \"1.0.0\"\n").unwrap();
         let paths = Paths::from_root(&dir).unwrap();
-        fs::create_dir_all(paths.dependencies.join("lib1-1.0.0").join("src")).unwrap();
+        create_dir_with_sol(&paths.dependencies.join("lib1-1.0.0").join("src"));
         write_lock(&paths, &[("lib1", "1.0.0")]);
         let config = SoldeerConfig::default();
 
-        let existing_deps = vec![("lib1-1.0.0/", "dependencies/lib1-1.0.0/")];
+        let existing_deps = vec![("lib1-1.0.0/", "dependencies/lib1-1.0.0/src/")];
         let merged =
             generate_remappings(&RemappingsAction::Update, &paths, &config, &existing_deps)
                 .unwrap();

--- a/crates/core/src/remappings.rs
+++ b/crates/core/src/remappings.rs
@@ -766,6 +766,27 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
     }
 
     #[test]
+    fn test_generate_remappings_update_suffix_is_consistent() {
+        // The path a dependency is remapped to must not depend on whether a
+        // remappings file happened to exist: generating from scratch and
+        // merging into existing remappings have to agree.
+        let dir = testdir!();
+        fs::write(dir.join("soldeer.toml"), "[dependencies]\nlib1 = \"1.0.0\"\n").unwrap();
+        let paths = Paths::from_root(&dir).unwrap();
+        fs::create_dir_all(paths.dependencies.join("lib1-1.0.0").join("src")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
+        let config = SoldeerConfig::default();
+
+        let existing_deps = vec![("lib1-1.0.0/", "dependencies/lib1-1.0.0/")];
+        let merged =
+            generate_remappings(&RemappingsAction::Update, &paths, &config, &existing_deps)
+                .unwrap();
+        let from_scratch =
+            generate_remappings(&RemappingsAction::Update, &paths, &config, &[]).unwrap();
+        assert_eq!(merged, from_scratch);
+    }
+
+    #[test]
     fn test_generate_remappings_add() {
         let dir = testdir!();
         fs::write(dir.join("soldeer.toml"), "[dependencies]\n").unwrap();

--- a/crates/core/src/remappings.rs
+++ b/crates/core/src/remappings.rs
@@ -374,9 +374,11 @@ fn remappings_from_deps(
         .map(|dependency| {
             let dependency_name_formatted = format_remap_name(soldeer_config, dependency); // contains trailing slash
             let relative_path = get_install_dir_relative(dependency, paths, locked)?;
-            let suffix = source_dir_suffix(&paths.root.join(&relative_path));
+            // The source-dir suffix is inferred only on install (`Add`). On update we
+            // must not reintroduce a `src/` the user deliberately removed, and the
+            // path must not depend on whether a remappings file already existed.
             Ok((
-                format!("{dependency_name_formatted}={relative_path}/{suffix}"),
+                format!("{dependency_name_formatted}={relative_path}/"),
                 dependency.clone(),
             )
                 .into())

--- a/crates/core/src/remappings.rs
+++ b/crates/core/src/remappings.rs
@@ -766,6 +766,23 @@ dep3 = { version = "foobar", git = "git@github.com:test/test.git", branch = "foo
     }
 
     #[test]
+    fn test_generate_remappings_regenerate_keeps_user_removed_source_suffix() {
+        // Same invariant as above, but with `remappings_regenerate` enabled: the
+        // suffix must not come back there either, otherwise every install,
+        // update or uninstall silently rewrites the user's remappings.
+        let dir = testdir!();
+        fs::write(dir.join("soldeer.toml"), "[dependencies]\nlib1 = \"1.0.0\"\n").unwrap();
+        let paths = Paths::from_root(&dir).unwrap();
+        fs::create_dir_all(paths.dependencies.join("lib1-1.0.0").join("src")).unwrap();
+        write_lock(&paths, &[("lib1", "1.0.0")]);
+        let config = SoldeerConfig { remappings_regenerate: true, ..Default::default() };
+
+        let existing_deps = vec![("lib1-1.0.0/", "dependencies/lib1-1.0.0/")];
+        let res = generate_remappings(&RemappingsAction::Update, &paths, &config, &existing_deps);
+        assert_eq!(res.unwrap(), vec!["lib1-1.0.0/=dependencies/lib1-1.0.0/"]);
+    }
+
+    #[test]
     fn test_generate_remappings_update_suffix_is_consistent() {
         // The path a dependency is remapped to must not depend on whether a
         // remappings file happened to exist: generating from scratch and


### PR DESCRIPTION
Fixes #236

## Problem

Soldeer generates `forge-std/=dependencies/forge-std-1.9.4/` without the source subdirectory, unlike `forge remappings` which detects `src/` / `contracts/`. This makes imports non-canonical (e.g. `import {Script} from "forge-std/src/Script.sol";`).

## Change

When a remapping is first generated (add / regenerate / a newly added dependency during update), infer the source subdirectory — `src`, then `contracts`, matching Foundry's default layouts — and append it.

**Respecting @beeb's constraint** that the inference must not be permanent: the update path replaces only the install-directory portion of an existing remapping, so a user who removes the auto-detected `src/` suffix will not see it come back on the next update. This is covered by a dedicated regression test.

## Testing

Added tests for the inference (`test_generate_remappings_add_infers_source_dir`) and for suffix preservation on update (`test_generate_remappings_update_keeps_user_removed_source_suffix`). The full `soldeer-core` suite passes.

Note: this covers the standard `src`/`contracts` layouts; a deeper breadth-first search (as discussed in the issue) could follow if needed.